### PR TITLE
[cmake] Keep unit tests as optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,10 @@ else()
 						            spdlog::spdlog)
 endif()
 
-add_subdirectory(test)
+if (BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
 INSTALL(TARGETS up-cpp)
 INSTALL(DIRECTORY include DESTINATION .)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ cmake_minimum_required(VERSION 3.10.0)
 set(CMAKE_CXX_STANDARD 17)
 project(up-cpp  LANGUAGES CXX)
 
+option(UP_CPP_BUILD_TESTING "Build the tests" ON)
+
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 	include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 	conan_basic_setup()
@@ -83,7 +85,7 @@ else()
 						            spdlog::spdlog)
 endif()
 
-if (BUILD_TESTING)
+if (BUILD_TESTING OR UP_CPP_BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
When packaging Up-cpp (e.g. Conan), unit tests are not needed, so the usual flow is skipping it.

This PR adds the option `UP_CPP_BUILD_TESTING`, and supports the native CMake option `BUILD_TESTING` (https://cmake.org/cmake/help/latest/command/enable_testing.html)

It will build tests by default, but will give the option to skip it.