### PR TITLE
Clarifying conan responsibility of source, install, build, create

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
   
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
@@ -23,37 +23,66 @@ jobs:
       - name: Conan version
         run: echo "${{ steps.conan.outputs.version }}"
 
-
       - name: Create default Conan profile
         run: conan profile detect
 
-
-      - name: Fetch and link up-core-api
+      - name: Build & install up-cpp
         shell: bash
         run: |
-          git clone -b uprotocol-core-api-1.5.6 https://github.com/eclipse-uprotocol/up-core-api.git
-          git submodule update --init --recursive
-
-      - name: Build && install up-cpp
-        shell: bash
-        run: |
-          mkdir -p build && cd build
-          conan install .. -o build_testing=True
-          cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=~/local
-          cmake --build . --target install -- -j
+          conan source .
+          conan build . --build=missing -o build_testing=True
 
       - name: Run the test
         shell: bash
         run: |
-          cd build
+          cd build/Release
           ctest
+
+  local-package:
+    name: Local Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Conan
+        id: conan
+        uses: turtlebrowser/get-conan@main
+
+      - name: Conan version
+        run: echo "${{ steps.conan.outputs.version }}"
+
+      - name: Create default Conan profile
+        run: conan profile detect
 
       - name: Create up-cpp Conan package
         shell: bash
         run: |
-          conan create . --build=missing
-  
-  
+          conan create . --build=missing          
+
+  cci-package:
+    name: Conan Center Index Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Conan
+        id: conan
+        uses: turtlebrowser/get-conan@main
+
+      - name: Conan version
+        run: echo "${{ steps.conan.outputs.version }}"
+
+      - name: Create default Conan profile
+        run: conan profile detect
+
+      - name: Create up-cpp Conan package for Conan Center Index
+        shell: bash
+        run: |
+          cd conan-recipes/cci/all
+          conan create . --build=missing --version 0.1.2-dev        
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -62,7 +91,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [test, local-package, cci-package]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,15 @@
-.idea/*
-build/*
-CMakeCache.txt
-CMakeFiles/
-Makefile
-cmake-build-debug/
-cmake-build-release/
-cmake_install.cmake
-/proto/cloudevents.pb.cc
-/proto/cloudevents.pb.h
-/proto/libproto.a
-/test_app
-/libcloudeventGM.a
-/json_serializer_test
-/binary_serializer_test
-/service_type_test
-.vscode/settings.json
-/.cmake/
+# ignore editor caches
+.vscode/
+.idea/
+
+# ensure we don't check in the cloned .proto
+up-core-api/
+
+# ignore build artifacts
+build/
 /build.ninja
-/Testing/Temporary/LastTest.log
 /.ninja_deps
 /.ninja_log
-.vscode
-up-core-api/
-/include/uprotocol-cpp/uri/datamodel/
+
+# ignore presets file generated as part of conan install
+CMakeUserPresets.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "up-core-api"]
-	path = up-core-api
-	url = https://github.com/eclipse-uprotocol/up-core-api.git

--- a/README.md
+++ b/README.md
@@ -30,35 +30,112 @@ CMakeToolchain
 
 [layout]
 cmake_layout
-
 ```
 **NOTE:** If using conan version 1.59 Ensure that the conan profile is configured to use ABI 11 (libstdc++11: New ABI.) standards according to https://docs.conan.io/en/1.60/howtos/manage_gcc_abi.html
+
+**NOTE:** Until `up-cpp` makes it to Conan Center Index, to use the
+library you must follow section below on creating conan package locally.
 
 ## How to Build 
 The following steps are only required to locally build and test up-cpp, if you are a user of up-cpp, you only need to follow the _How to Use the Library_ section above. 
 ### Setup SDK local repository, build and test
+```bash
+git clone https://github.com/eclipse-uprotocol/up-cpp.git
+cd up-cpp
+conan source .
 ```
-$ git clone https://github.com/eclipse-uprotocol/up-cpp.git
-$ git submodule update --init --recursive
+
+**Note that**:
+```bash
+conan source .
+```
+will clone the repo holding the project `.proto`s.
+
+If you would rather use `ssh` to clone, you can instead invoke:
+```bash
+GIT_METHOD=ssh conan source .
 ```
 
 ### Building locally 
-```
-$ cd up-cpp
-$ mkdir build
-$ cd build
 
-$ conan install .. -o build_testing=True
-$ cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON  -DCMAKE_INSTALL_PREFIX=install
-$ cmake --build . --target install -- -j 
+#### Using Conan for build
+
+Most will probably be fine building using Conan as follows:
+```bash
+cd up-cpp
+conan build . --build=missing -o build_testing=True
+```
+Places the build artifacts in `up-cpp/build/Release`.
+
+#### Using Conan for dependencies only
+
+If you need to, you can use Conan to only install dependencies
+and scaffold out for building using CMake.
+```bash
+cd up-cpp
+conan install . --build=missing -o build_testing=True
+cmake --preset conan-release
+cd build
+cmake --build Release --target install -- -j
 ```
 
 ### Creating conan package locally 
-If you need to create a release package for conan, please follow the steps below.
 
+If you need to create a release package for conan, please follow the steps below.
+```bash
+cd up-cpp
+conan create ./conanfile_package.py --build=missing
 ```
-$ cd up-cpp
-$ conan create . --build=missing
+Installs the `up-cpp` package in your local conan cache.
+* `~/.conan` if using Conan 1.59
+* `~/.conan2` if using Conan 2.X
+
+### Updating to use new spec's `.proto`s
+
+#### Add new release tag to `conandata.yml`:
+
+Before:
+```yaml
+proto:
+  # When new spec is released, replace this entry with the new spec release version and tag
+  "1.5.7":
+    ssh: "git@github.com:eclipse-uprotocol/up-core-api.git"
+    https: "https://github.com/eclipse-uprotocol/up-core-api.git"
+    sha256: "c5ad309f74db78a6d2154886404e3c13895f3dd50846ac526b5b0b3433005414"
+    tag: "uprotocol-core-api-1.5.7"
+```
+After:
+```yaml
+proto:
+  # When new spec is released, replace this entry with the new spec release version and tag
+  "1.5.8":
+    ssh: "git@github.com:eclipse-uprotocol/up-spec.git"
+    https: "https://github.com/eclipse-uprotocol/up-spec.git"
+    sha256: "1a1dc5d1d2bbfcda92228d6fa4b16fa3cdb5a3c96f46606209fd45bae7b993a3"
+    # tentative -- replace with actual tag
+    tag: "uprotocol-1.5.8"
+```
+
+#### Update `conanfile.py` to use new tag
+```python
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_version = "1.5.8
+    proto_version = "1.5.7"
+```
+
+### One-time changes due to merging of `up-core-api` and `up-spec`
+
+This section can be removed later after the release of `1.5.8` and
+the changes performed.
+
+Update `conanfile.py` as is commented and remove the TODOs:
+```python
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_containing_folder = "up-spec"
+    proto_containing_folder = "up-core-api"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_subfolder = "up-core-api"
+    proto_subfolder = "."
 ```
 
 ## Show your support

--- a/cmake/up-core-api-protos.cmake
+++ b/cmake/up-core-api-protos.cmake
@@ -21,10 +21,10 @@ cmake_minimum_required(VERSION 3.18)
 set(CMAKE_CURRENT_SOURCE_DIR_TO_RESTORE ${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(protobuf CONFIG REQUIRED)
-if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/up-core-api/uprotocol/")
-    set(MY_IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/up-core-api/uprotocol/")
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_PATH}")
+    set(MY_IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_PATH}")
 else()
-    message(FATAL_ERROR "Could not find up-core-api. Please, set UP_CORE_API_ROOT_DIR to the root directory of up-core-api.")
+    message(FATAL_ERROR "Could not find up-core-api protos. Please run conan source . to clone them.")
 endif()
 
 set(CMAKE_CURRENT_SOURCE_DIR ${MY_IMPORT_DIRS})

--- a/conan-recipes/cci/all/conandata.yml
+++ b/conan-recipes/cci/all/conandata.yml
@@ -1,0 +1,12 @@
+sources:
+  # Newer versions at the top
+  "0.1.2-dev":
+    url: "https://github.com/eclipse-uprotocol/up-cpp/archive/refs/tags/v0.1.2-dev.tar.gz"
+    sha256: "1c1006256d0e5fd385732767e0e3b0b4867342e29e4c74e11a0d8a9a763c1288"
+patches:
+  # Newer versions at the top
+proto:
+  "0.1.2-dev":
+    ssh: "git@github.com:eclipse-uprotocol/up-core-api.git"
+    https: "https://github.com/eclipse-uprotocol/up-core-api.git"
+    tag: "uprotocol-core-api-1.5.7"

--- a/conan-recipes/cci/all/conanfile.py
+++ b/conan-recipes/cci/all/conanfile.py
@@ -1,0 +1,168 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, collect_libs
+from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version, Git
+import os
+
+required_conan_version = ">=1.59.0"
+
+class UpCppConan(ConanFile):
+    name = "up-cpp"
+    description = "C++ language implementation of a uProtocol language SDK"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eclipse-uprotocol/up-cpp"
+    topics = ("uProtocol", "SDV", "middleware")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_containing_folder = "up-spec"
+    proto_containing_folder = "up-core-api"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_subfolder = "up-core-api"
+    proto_subfolder = "."
+    proto_folder = "uprotocol"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "build_testing": [True, False],
+        "build_unbundled": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": False,
+        "build_testing": False,
+        "build_unbundled": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    # in case the project requires C++14/17/20/... the minimum compiler version should be listed
+    # unclear on what I should choose for msvc and Visual Studio
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "13",
+            "clang": "13",
+            "gcc": "11",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    # no exports_sources attribute, but export_sources(self) method instead
+    # this allows finer grain exportation of patches per version
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+        self.folders.build = os.path.join("build", str(self.settings.build_type))
+        self.folders.install = "install"
+
+        # this was what was here previously
+        # src_folder must use the same source folder name the project - TODO: think this is ok?
+        # cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("protobuf/3.21.12")
+        self.requires("spdlog/1.13.0")
+        if self.options.build_testing:
+            self.requires("gtest/1.14.0")
+
+    def validate(self):
+        # validate the minimum cpp standard supported. For C++ projects only
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+        # in case it does not work in another configuration, it should validated here too
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+        # we clone protos from the appropriate repo at the appropriate tag to our local root to build
+        rmdir(self, self.proto_containing_folder)
+
+        git = Git(self)
+        git_method = os.getenv("GIT_METHOD", "https")
+        git.clone(self.conan_data["proto"][self.version][git_method], target=self.proto_containing_folder)
+        git.folder=self.proto_containing_folder
+        git.checkout(self.conan_data["proto"][self.version]["tag"])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PROTO_PATH"] = os.path.join(self.proto_containing_folder, os.path.join(self.proto_subfolder, self.proto_folder))
+        tc.variables["BUILD_TESTING"] = self.options.build_testing
+        tc.variables["BUILD_UNBUNDLED"] = self.options.build_unbundled
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        if is_msvc(self):
+            # don't use self.settings.compiler.runtime - TODO: unclear if relevant
+            tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+        tc.generate()
+        # In case there are dependencies listed on requirements, CMakeDeps should be used - TODO: relevant?
+        tc = CMakeDeps(self)
+        tc.generate()
+        # In case there are dependencies listed on build_requirements, VirtualBuildEnv should be used - TODO: relevant?
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()  # It can be apply_conandata_patches(self) only in case no more patches are needed
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        # some files extensions and folders are not allowed. Please, read the FAQs to get informed.
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["up-cpp"]
+
+        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("dl")
+
+        self.cpp_info.set_property("cmake_file_name", "up-cpp")
+        self.cpp_info.set_property("cmake_target_name", "up-cpp::up-cpp")
+        self.cpp_info.set_property("pkg_config_name", "up-cpp")
+        self.cpp_info.libs = collect_libs(self)
+
+        self.cpp_info.set_property("cmake_target_name", "up-cpp::up-cpp")
+        self.cpp_info.requires = ["spdlog::spdlog", "protobuf::protobuf"]
+
+        self.cpp_info.names["cmake_find_package"] = "up-cpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "up-cpp"

--- a/conan-recipes/cci/all/test_package/CMakeLists.txt
+++ b/conan-recipes/cci/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX) # if the project uses c++
+
+find_package(up-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+# don't link to ${CONAN_LIBS} or CONAN_PKG::package
+target_link_libraries(${PROJECT_NAME} PRIVATE up-cpp::up-cpp)
+# In case the target project need a specific C++ standard
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/conan-recipes/cci/all/test_package/conanfile.py
+++ b/conan-recipes/cci/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires("protobuf/3.21.12")
+        self.requires("spdlog/1.13.0")
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/conan-recipes/cci/all/test_package/test_package.cpp
+++ b/conan-recipes/cci/all/test_package/test_package.cpp
@@ -1,0 +1,21 @@
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include <up-cpp/uuid/factory/Uuidv8Factory.h>
+#include <up-cpp/uuid/serializer/UuidSerializer.h>
+
+using namespace uprotocol::uuid;
+using namespace uprotocol::v1;
+
+int main(void) {
+
+    UUID uuId = Uuidv8Factory::create();
+    std::vector<uint8_t> vectUuid = UuidSerializer::serializeToBytes(uuId);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vectUuid);
+
+    std::string str = "0080b636-8303-8701-8ebe-7a9a9e767a9f";
+    UUID uuIdNew = UuidSerializer::deserializeFromString(str);
+
+    return EXIT_SUCCESS;
+}

--- a/conan-recipes/cci/config.yml
+++ b/conan-recipes/cci/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.2-dev":
+    folder: all

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,4 +1,7 @@
-sources:
-  "0.1.2":
-    url: "https://github.com/MelamudMichael/up-cpp/archive/refs/tags/0.1.2.tar.gz"
-    sha256: "ac9c80e6c809ba88fd6f85ed05eaef5d3e13c6aee9de4529b8664daeaca64209"
+proto:
+  # When new spec is released, replace this entry with the new spec release version and tag
+  "1.5.7":
+    ssh: "git@github.com:eclipse-uprotocol/up-core-api.git"
+    https: "https://github.com/eclipse-uprotocol/up-core-api.git"
+    sha256: "c5ad309f74db78a6d2154886404e3c13895f3dd50846ac526b5b0b3433005414"
+    tag: "uprotocol-core-api-1.5.7"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,52 +1,75 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.scm import Git
+from conan.tools.files import rmdir
 import os
 
-class UpCpp(ConanFile):
+class UpCppLocal(ConanFile):
     name = "up-cpp"
     package_type = "library"
     license = "Apache-2.0 license"
     homepage = "https://github.com/eclipse-uprotocol"
     url = "https://github.com/conan-io/conan-center-index"
     description = "This module contains the data model structures as well as core functionality for building uProtocol"
-    topics = ("utransport sdk", "transport")
+    topics = ("uProtocol", "SDV", "middleware")
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
     conan_version = None
     generators = "CMakeDeps", "PkgConfigDeps", "VirtualRunEnv", "VirtualBuildEnv"
     version = "0.1.2-dev"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_version = "1.5.8
+    proto_version = "1.5.7"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_containing_folder = "up-spec"
+    proto_containing_folder = "up-core-api"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_subfolder = "up-core-api"
+    proto_subfolder = "."
+    proto_folder = "uprotocol"
     exports_sources = "CMakeLists.txt", "up-core-api/*", "include/*" ,"src/*" , "test/*", "cmake/*"
-
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "build_testing": [True, False],
         "build_unbundled": [True, False],
-        "build_cross_compiling": [True, False],
     }
-
     default_options = {
         "shared": False,
         "fPIC": False,
         "build_testing": False,
         "build_unbundled": False,
-        "build_cross_compiling": False,
     }
-        
-    def requirements(self):
-        self.requires("protobuf/3.21.12" + ("@cross/cross" if self.options.build_cross_compiling else ""))
-        self.requires("spdlog/1.13.0")
-        if self.options.build_testing:
-            self.requires("gtest/1.14.0")
+
+    def layout(self):
+        cmake_layout(self)
+        self.folders.build = os.path.join("build", str(self.settings.build_type))
+        self.folders.install = "install"
+
+    def source(self):
+        # we clone protos from the appropriate repo at the appropriate tag to our local root to build
+        rmdir(self, self.proto_containing_folder)
+
+        git = Git(self)
+        git_method = os.getenv("GIT_METHOD", "https")
+        git.clone(self.conan_data["proto"][self.proto_version][git_method], target=self.proto_containing_folder)
+        git.folder=self.proto_containing_folder
+        git.checkout(self.conan_data["proto"][self.proto_version]["tag"])
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["PROTO_PATH"] = os.path.join(self.proto_containing_folder, os.path.join(self.proto_subfolder, self.proto_folder))
         tc.variables["BUILD_TESTING"] = self.options.build_testing
         tc.variables["BUILD_UNBUNDLED"] = self.options.build_unbundled
         tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["CMAKE_INSTALL_PREFIX"] = self.folders.install
         tc.generate()
+
+    def requirements(self):
+        self.requires("protobuf/3.21.12")
+        self.requires("spdlog/1.13.0")
+        if self.options.build_testing:
+            self.requires("gtest/1.14.0")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
# What

  * conanfile.py contains the Conan recipes to build & package
  * updated conanfile.py to add source() method which clones the .proto holding repository
  * updated up-core-api-protos.cmake to appropriately refer to location of .proto definitions set in conanfile.py, making it future proof
  * updated GitHub workflow for new build steps
  * updated GitHub workflow to separate test & package flows


# Why

We want to support local builds & packaging.

# To Dos

- [ ] Update README.md to discuss how to make releases to CCI
- [ ] Confirm that the CCI package can be accepted into CCI

# Next Steps

We also want to separately create an entry into [Conan Center Index](https://github.com/conan-io/conan-center-index) to support pulling `up-cpp` packages directly for users.