### PR TITLE
Removing stale comments, improve readability

### DIFF
--- a/include/up-cpp/datamodel/validator/UUri.h
+++ b/include/up-cpp/datamodel/validator/UUri.h
@@ -74,6 +74,13 @@ using ValidationResult = std::tuple<bool, std::optional<Reason>>;
 /// resource_id must be 0.
 [[nodiscard]] ValidationResult isValidRpcResponse(const v1::UUri&);
 
+/// @brief Checks if UUri is valid as a default source on a UTransport.
+///
+/// @note This just calls isValidRpcResponse() because the requirements are the
+///       same in both cases. It is provided as a separate function here for
+///       improved readability where it is called.
+[[nodiscard]] ValidationResult isValidDefaultSource(const v1::UUri&);
+
 /// @brief Checks if UUri is valid for publishing to a topic, OR as a source
 ///        and sink for sending notifications, OR as a sink for receiving
 ///        notifications.

--- a/include/up-cpp/transport/UTransport.h
+++ b/include/up-cpp/transport/UTransport.h
@@ -53,9 +53,9 @@ public:
 	///        transport instance.
 	///
 	/// @throws InvalidUUri if the provided UUri is not valid as a default
-	///         source. Validation is done with isValidRpcResponse().
+	///         source. Validation is done with isValidDefaultSource().
 	///
-	/// @see uprotocol::datamodel::validator::uri::isValidRpcResponse()
+	/// @see uprotocol::datamodel::validator::uri::isValidDefaultSource()
 	/// @see uprotocol::datamodel::validator::uri::InvalidUUri
 	explicit UTransport(const v1::UUri&);
 
@@ -127,9 +127,6 @@ protected:
 	///
 	/// @param message UMessage to be sent.
 	///
-	/// @throws InvalidUMessage if the message doesn't pass the isValid() check.
-	/// @see uprotocol::datamodel::validator::message::isValid()
-	///
 	/// @returns * OKSTATUS if the payload has been successfully
 	///            sent (ACK'ed)
 	///          * FAILSTATUS with the appropriate failure.
@@ -163,9 +160,6 @@ protected:
 	///
 	/// @returns * OKSTATUS if the listener was registered successfully.
 	///          * FAILSTATUS with the appropriate failure otherwise.
-	/// @TODO(gregmedd) What is this for? Presumably for RPC responses, but
-	///                 that scenario requires filtering by request ID not
-	///                 source, and that would be handled at the next layer up.
 	[[nodiscard]] virtual v1::UStatus registerListenerImpl(
 	    const v1::UUri& sink_filter, CallableConn&& listener,
 	    std::optional<v1::UUri>&& source_filter) = 0;


### PR DESCRIPTION
Stale comments in UTransport provided misleading requirements for transport implementers, implying that the transport implementation was responsible for validating messages. These comments have been removed.

Additionally, the reference to the UTransport constructor checking default URIs against the isValidRpcResponse() URI validator was causing some confusion. This validator *does* provide the correct validation rulse for this use case since the default source will always have its resource ID replaced. However, a new isValidDefaultSource() validator has been added to improve readability.