### PR TITLE
clang-format: Extend default line length

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ DerivePointerAlignment: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 FixNamespaceComments: 'true'
 PointerAlignment: Left
+ColumnLimit: 100
 
 TabWidth: 4
 IndentWidth: 4


### PR DESCRIPTION
Line length of 80 characters is too short in several cases where nested statements are used and long variable names cause the line to be wrapped and makes the code less readable.  Additionally, most tools (vscode, etc) allow for showing far more than 80 characters per line.