### PR TITLE
UUriValidator : authority_name can be empty (sometimes)

### DIFF
--- a/src/datamodel/validator/UUri.cpp
+++ b/src/datamodel/validator/UUri.cpp
@@ -79,10 +79,6 @@ ValidationResult isValid(const v1::UUri& uuri) {
 }
 
 ValidationResult isValidRpcMethod(const v1::UUri& uuri) {
-	if (uuri.authority_name().empty()) {
-		return {false, Reason::EMPTY};
-	}
-
 	// disallow wildcards
 	if (uses_wildcards(uuri)) {
 		return {false, Reason::DISALLOWED_WILDCARD};
@@ -97,10 +93,6 @@ ValidationResult isValidRpcMethod(const v1::UUri& uuri) {
 }
 
 ValidationResult isValidRpcResponse(const v1::UUri& uuri) {
-	if (uuri.authority_name().empty()) {
-		return {false, Reason::EMPTY};
-	}
-
 	// disallow wildcards
 	if (uses_wildcards(uuri)) {
 		return {false, Reason::DISALLOWED_WILDCARD};
@@ -113,14 +105,14 @@ ValidationResult isValidRpcResponse(const v1::UUri& uuri) {
 }
 
 ValidationResult isValidDefaultSource(const v1::UUri& uuri) {
-	return isValidRpcResponse(uuri);
-}
-
-ValidationResult isValidPublishTopic(const v1::UUri& uuri) {
 	if (uuri.authority_name().empty()) {
 		return {false, Reason::EMPTY};
 	}
 
+	return isValidRpcResponse(uuri);
+}
+
+ValidationResult isValidPublishTopic(const v1::UUri& uuri) {
 	// disallow wildcards
 	if (uses_wildcards(uuri)) {
 		return {false, Reason::DISALLOWED_WILDCARD};
@@ -134,10 +126,6 @@ ValidationResult isValidPublishTopic(const v1::UUri& uuri) {
 }
 
 ValidationResult isValidNotification(const v1::UUri& uuri) {
-	if (uuri.authority_name().empty()) {
-		return {false, Reason::EMPTY};
-	}
-
 	// disallow wildcards
 	if (uses_wildcards(uuri)) {
 		return {false, Reason::DISALLOWED_WILDCARD};
@@ -155,10 +143,6 @@ ValidationResult isValidNotification(const v1::UUri& uuri) {
 }
 
 ValidationResult isValidSubscription(const v1::UUri& uuri) {
-	if (uuri.authority_name().empty()) {
-		return {false, Reason::EMPTY};
-	}
-
 	if (uuri.resource_id() < 0x8000 || uuri.resource_id() > 0xFFFF) {
 		return {false, Reason::BAD_RESOURCE_ID};
 	}

--- a/test/coverage/datamodel/UUriValidatorTest.cpp
+++ b/test/coverage/datamodel/UUriValidatorTest.cpp
@@ -50,8 +50,8 @@ TEST_F(TestUUriValidator, Valid) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValid(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -180,8 +180,8 @@ TEST_F(TestUUriValidator, ValidRpcMethod) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValidRpcMethod(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -230,8 +230,8 @@ TEST_F(TestUUriValidator, ValidRpcResponse) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValidRpcResponse(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -280,8 +280,8 @@ TEST_F(TestUUriValidator, ValidPublishTopic) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValidPublishTopic(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -338,8 +338,8 @@ TEST_F(TestUUriValidator, ValidNotification) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValidNotification(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -397,8 +397,8 @@ TEST_F(TestUUriValidator, ValidSubscription) {
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
 		auto [valid, reason] = isValidSubscription(uuri);
-		EXPECT_FALSE(valid);
-		EXPECT_TRUE(reason == Reason::EMPTY);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
@@ -423,6 +423,25 @@ TEST_F(TestUUriValidator, ValidSubscription) {
 		auto [valid, reason] = isValidSubscription(uuri);
 		EXPECT_TRUE(valid);
 		EXPECT_FALSE(reason.has_value());
+	}
+}
+
+TEST_F(TestUUriValidator, ValidDefaultSource) {
+	auto getUuri = []() {
+		uprotocol::v1::UUri uuri;
+		uuri.set_authority_name(AUTHORITY_NAME);
+		uuri.set_ue_id(0x00010001);
+		uuri.set_ue_version_major(1);
+		uuri.set_resource_id(0x8000);
+		return uuri;
+	};
+
+	{
+		auto uuri = getUuri();
+		uuri.set_authority_name("");
+		auto [valid, reason] = isValidDefaultSource(uuri);
+		EXPECT_FALSE(valid);
+		EXPECT_TRUE(reason == Reason::EMPTY);
 	}
 }
 


### PR DESCRIPTION
Allow authority_name to be empty in most cases, but specifically should not be empty in isValidDefaultSource.  Also updated the tests to test an empty authority_name and pass except when isValidDefaultSource is used.

Addresses issue #149 