### PR TITLE
Pass UTransport's cleanup method for callbacks

### DIFF
--- a/src/transport/UTransport.cpp
+++ b/src/transport/UTransport.cpp
@@ -60,10 +60,12 @@ UTransport::registerListener(const v1::UUri& sink_filter,
 		}
 	}
 
-	auto [handle, callable] =
-	    CallbackConnection::establish(std::move(listener));
+	auto [handle, callable] = CallbackConnection::establish(
+	    std::move(listener), [this](auto conn) { cleanupListener(conn); });
+
 	v1::UStatus status = registerListenerImpl(sink_filter, std::move(callable),
 	                                          std::move(source_filter));
+
 	if (status.code() == v1::UCode::OK) {
 		return utils::Expected<ListenHandle, v1::UStatus>(std::move(handle));
 	} else {


### PR DESCRIPTION
This method should be called when the `CalleeHandle` breaks the connection so that derived transports can clean up connections should they choose to do so. Enable this by passing a lambda that calls the method.

closes #152 