### PR TITLE
Remove unused fields from RpcServer

### DIFF
--- a/include/up-cpp/communication/RpcServer.h
+++ b/include/up-cpp/communication/RpcServer.h
@@ -79,40 +79,17 @@ struct RpcServer {
 protected:
 	/// @brief Constructs an RPC server connected to a given transport.
 	///
-	/// @param transport Transport to offer the RPC method through.
-	/// @param method URI representing the name clients will use to invoke
-	///               the RPC method.
-	/// @param payload_format (Optional) If sending a payload, this sets the
-	///                       format that will be expected when the callback
-	///                       returns. Empty response payloads can only be
-	///                       sent if this was not set.
-	/// @param ttl (Optional) Time response will be valid from the moment
-	///            respond() is called. Note that the original request's TTL
-	///            may also still apply.
-	RpcServer(std::shared_ptr<transport::UTransport> transport,
-	          const v1::UUri& method,
-	          std::optional<v1::UPayloadFormat> format = {},
-	          std::optional<std::chrono::milliseconds> ttl = {});
-
-	/// @brief Connects the RPC callback method and returns the status from
-	///        UTransport::registerListener.
-	///
-	/// @param callback Method that will be called when requests are received.
-	///
-	/// @returns OK if connected successfully, error status otherwise.
-	[[nodiscard]] v1::UStatus connect(RpcCallback&& callback);
+	/// @param Connected callback handle for the RPC method wrapper as created
+	///        by calling UTransport::registerListener() within the create()
+	///        method.
+	RpcServer(transport::UTransport::ListenHandle);
 
 private:
-	/// @brief Transport instance that will be used for communication
-	std::shared_ptr<transport::UTransport> transport_;
-
-	/// @brief TTL to use for responses, if set at construction time
-	std::optional<std::chrono::milliseconds> ttl_;
-
-	/// @brief RPC callback method
-	RpcCallback callback_;
-
 	/// @brief Handle to the connected callback for the RPC method wrapper
+	///
+	/// @remarks The callback lambda represented by this handle will capture
+	///          all of the parameters needed to form responses found in the
+	///          create() method.
 	transport::UTransport::ListenHandle callback_handle_;
 };
 


### PR DESCRIPTION
RpcServer::create() will create a lambda that wraps around the user's callback. That wrapper will be registered with UTransport. Since the wrapper is already a lambda, all the parameters it needs to produce replies can be captured. As such, there is no need for the RpcServer instance itself to hold those values.

This simplifies the code for implementing RpcServer and reduces the risks of mistakes around setup.

The intent is that the body of RpcServer::create() will look approximately like this:

```
ServerOrStatus create(
	    std::shared_ptr<transport::UTransport> transport,
	    const v1::UUri& method_name, RpcCallback&& callback,
	    std::optional<v1::UPayloadFormat> payload_format = {},
	    std::optional<std::chrono::milliseconds> ttl = {}) {

    // Create a connection to the callback that was provided
    // something like: auto [handle, callable] = connection::Connection::establish(std::move(callback))

    // Create the wrapper
    auto wrapper = [transport, callback = std::move(callable),
                    payload_format = std::move(payload_format), ttl = std::move(ttl)] (const v1::UMessage& m) {
        // Call the callable and pass m (returns optional payload)
        // create a response message builder, passing m
        // if payload_format is set, set it on the message builder
        // if ttl is set, set it on the message builder
        // if payload was returned by the callable, call builder.build(*payload)
            // otherwise call builder.build()
        // Send the response message on the transport
    };

    // Register the wrapper with the transport
    // If successful, construct RpcServer with the handle from registerListener and return the handle for the wrapper
        // Otherwise, return the UStatus returned by registerListener
}
```