### PR TITLE
Refactor UTransportMock to remove lifecycle testing, and so make suitable for inclusion in other tests.

### DIFF
--- a/test/coverage/transport/UTransportTest.cpp
+++ b/test/coverage/transport/UTransportTest.cpp
@@ -19,27 +19,7 @@
 #include <random>
 #include <sstream>
 
-size_t get_page_count() {
-	using namespace std;
-
-	stringstream file_name;
-	file_name << "/proc/" << getpid() << "/statm";
-	int fd, len;
-	char buf[256];
-	memset(buf, 0, sizeof(buf));
-	if ((fd = open(file_name.str().c_str(), O_RDONLY)) < 0)
-		return 0;
-	if (read(fd, buf, sizeof(buf)) <= 0) {
-		close(fd);
-		return 0;
-	}
-	close(fd);
-	size_t tot, res_set_size, res_shared_pages, text_size, lib_size,
-	    data_and_stack, dirty;
-	sscanf(buf, "%lu%lu%lu%lu%lu%lu%lu", &tot, &res_set_size, &res_shared_pages,
-	       &text_size, &lib_size, &data_and_stack, &dirty);
-	return data_and_stack;
-}
+using MsgDiff = google::protobuf::util::MessageDifferencer;
 
 static std::random_device random_dev;
 static std::mt19937 random_gen(random_dev());
@@ -72,27 +52,15 @@ uprotocol::v1::UUID* make_uuid() {
 	return id;
 }
 
-auto& mock_info = uprotocol::test::UTransportMock::singleton();
-
 namespace {
 
 class TestMockUTransport : public testing::Test {
-	static size_t global_initial_page_count;
-	static size_t per_test_initial_page_count;
-
 protected:
 	// Run once per TEST_F.
 	// Used to set up clean environments per test.
-	void SetUp() override {
-		mock_info.reset();
-		per_test_initial_page_count = get_page_count();
-	}
+	void SetUp() override {}
 
-	void TearDown() override {
-		EXPECT_TRUE(mock_info.deinit_passed);
-		EXPECT_LE(get_page_count() - per_test_initial_page_count,
-		          50);  // check for per-test memory leaks
-	}
+	void TearDown() override {}
 
 	// Run once per execution of the test application.
 	// Used for setup of all tests. Has access to this instance.
@@ -101,34 +69,9 @@ protected:
 
 	// Run once per execution of the test application.
 	// Used only for global setup outside of tests.
-	static void SetUpTestSuite() {
-		global_initial_page_count = get_page_count();
-	}
-
-	static void TearDownTestSuite() {
-		EXPECT_LE(get_page_count() - global_initial_page_count,
-		          50);  // check for global memory leaks
-	}
+	static void SetUpTestSuite() {}
+	static void TearDownTestSuite() {}
 };
-
-size_t TestMockUTransport::global_initial_page_count;
-size_t TestMockUTransport::per_test_initial_page_count;
-
-using MsgDiff = google::protobuf::util::MessageDifferencer;
-
-TEST_F(TestMockUTransport, ConstructDestroy) {
-	uprotocol::v1::UUri def_src_uuri;
-	def_src_uuri.set_authority_name(get_random_string());
-	def_src_uuri.set_ue_id(0x18000);
-	def_src_uuri.set_ue_version_major(1);
-	def_src_uuri.set_resource_id(0);
-
-	auto transport =
-	    std::make_shared<uprotocol::test::UTransportMock>(def_src_uuri);
-	EXPECT_TRUE(mock_info.init_passed);
-	EXPECT_FALSE(mock_info.deinit_passed);
-	EXPECT_TRUE(MsgDiff::Equals(def_src_uuri, transport->getDefaultSource()));
-}
 
 TEST_F(TestMockUTransport, Send) {
 	using namespace std;
@@ -142,8 +85,6 @@ TEST_F(TestMockUTransport, Send) {
 	auto transport =
 	    std::make_shared<uprotocol::test::UTransportMock>(def_src_uuri);
 	EXPECT_NE(nullptr, transport);
-	EXPECT_TRUE(mock_info.init_passed);
-	EXPECT_FALSE(mock_info.deinit_passed);
 	EXPECT_TRUE(MsgDiff::Equals(def_src_uuri, transport->getDefaultSource()));
 
 	const size_t max_count = 1000 * 100;
@@ -171,14 +112,14 @@ TEST_F(TestMockUTransport, Send) {
 		uprotocol::v1::UMessage msg;
 		msg.set_allocated_attributes(attr);
 		msg.set_payload(get_random_string(1400));
-		mock_info.send_status.set_code(
+		transport->send_status_.set_code(
 		    static_cast<uprotocol::v1::UCode>(15 - (i % 16)));
-		mock_info.send_status.set_message(get_random_string());
+		transport->send_status_.set_message(get_random_string());
 
 		auto result = transport->send(msg);
-		EXPECT_EQ(i + 1, mock_info.send_count);
-		EXPECT_TRUE(MsgDiff::Equals(result, mock_info.send_status));
-		EXPECT_TRUE(MsgDiff::Equals(msg, mock_info.message));
+		EXPECT_EQ(i + 1, transport->send_count_);
+		EXPECT_TRUE(MsgDiff::Equals(result, transport->send_status_));
+		EXPECT_TRUE(MsgDiff::Equals(msg, transport->message_));
 	}
 }
 
@@ -194,8 +135,6 @@ TEST_F(TestMockUTransport, registerListener) {
 	auto transport =
 	    std::make_shared<uprotocol::test::UTransportMock>(def_src_uuri);
 	EXPECT_NE(nullptr, transport);
-	EXPECT_TRUE(mock_info.init_passed);
-	EXPECT_FALSE(mock_info.deinit_passed);
 	EXPECT_TRUE(MsgDiff::Equals(def_src_uuri, transport->getDefaultSource()));
 
 	uprotocol::v1::UUri sink_filter;
@@ -218,15 +157,15 @@ TEST_F(TestMockUTransport, registerListener) {
 	};
 	auto lhandle =
 	    transport->registerListener(sink_filter, action, source_filter);
-	EXPECT_TRUE(mock_info.listener);
+	EXPECT_TRUE(transport->listener_);
 	// EXPECT_EQ(*mock_info.listener, action); // need exposed target_type() to
 	// make comparable.
 	EXPECT_TRUE(lhandle.has_value());
 	auto handle = std::move(lhandle).value();
 	EXPECT_TRUE(handle);
-	EXPECT_TRUE(MsgDiff::Equals(sink_filter, mock_info.sink_filter));
-	EXPECT_TRUE(mock_info.source_filter);
-	EXPECT_TRUE(MsgDiff::Equals(source_filter, *mock_info.source_filter));
+	EXPECT_TRUE(MsgDiff::Equals(sink_filter, transport->sink_filter_));
+	EXPECT_TRUE(transport->source_filter_);
+	EXPECT_TRUE(MsgDiff::Equals(source_filter, *transport->source_filter_));
 
 	const size_t max_count = 1000 * 100;
 	for (auto i = 0; i < max_count; i++) {
@@ -234,14 +173,10 @@ TEST_F(TestMockUTransport, registerListener) {
 		auto attr = new uprotocol::v1::UAttributes();
 		msg.set_allocated_attributes(attr);
 		msg.set_payload(get_random_string(1400));
-		mock_info.mock_message(msg);
+		transport->mockMessage(msg);
 		EXPECT_EQ(i + 1, capture_count);
 		EXPECT_TRUE(MsgDiff::Equals(msg, capture_msg));
 	}
-	handle.reset();
-	EXPECT_TRUE(mock_info.cleanupListener);
-	// EXPECT_EQ(*mock_info.cleanupListener, action); // need exposed
-	// target_type() to make comparable.
 }
 
 }  // namespace

--- a/test/coverage/transport/UTransportTest.cpp
+++ b/test/coverage/transport/UTransportTest.cpp
@@ -72,12 +72,7 @@ uprotocol::v1::UUID* make_uuid() {
 	return id;
 }
 
-namespace uprotocol::test {
-uprotocol::test::UTransportMockInfo UTransportMock::mock_info =
-    uprotocol::test::UTransportMockInfo();
-};
-
-auto& mock_info = uprotocol::test::UTransportMock::mock_info;
+auto& mock_info = uprotocol::test::UTransportMock::singleton();
 
 namespace {
 

--- a/test/include/UTransportMock.h
+++ b/test/include/UTransportMock.h
@@ -17,81 +17,52 @@
 
 namespace uprotocol::test {
 
-struct UTransportMockInfo {
-	bool init_passed;
-	bool deinit_passed;
-	size_t send_count;
-	uprotocol::v1::UStatus send_status;
-	std::optional<uprotocol::utils::callbacks::CallerHandle<
-	    void, uprotocol::v1::UMessage const&>>
-	    listener;
-	std::optional<uprotocol::utils::callbacks::CallerHandle<
-	    void, uprotocol::v1::UMessage const&>>
-	    cleanupListener;
-	std::optional<uprotocol::v1::UUri> source_filter;
-	v1::UUri sink_filter;
-	v1::UMessage message;
-
-	void reset() {
-		init_passed = false;
-		deinit_passed = false;
-		send_count = 0;
-		listener.reset();
-		cleanupListener.reset();
-	}
-
-	UTransportMockInfo() { reset(); }
-
-	void mock_message(const uprotocol::v1::UMessage& msg) {
-		using namespace std;
-		ASSERT_TRUE(listener &&
-		            "registerListener must be set before calling mock_packet");
-		(*listener)(msg);
-	}
-};
-
 class UTransportMock : public uprotocol::transport::UTransport {
 public:
-	static UTransportMockInfo mock_info;
-
 	explicit UTransportMock(const v1::UUri& uuri)
-	    : uprotocol::transport::UTransport(uuri) {
-		mock_info.init_passed = true;
+	    : uprotocol::transport::UTransport(uuri), send_count_(0) {}
+
+	void mockMessage(const uprotocol::v1::UMessage& msg) {
+		ASSERT_TRUE(listener_ &&
+		            "registerListener must be set before calling mock_packet");
+		(*listener_)(msg);
 	}
 
-	~UTransportMock() { mock_info.deinit_passed = true; }
-
-	static UTransportMockInfo& singleton()
-	{
-		return mock_info;
-	}
+	size_t send_count_;
+	uprotocol::v1::UStatus send_status_;
+	std::optional<uprotocol::utils::callbacks::CallerHandle<
+	    void, uprotocol::v1::UMessage const&>>
+	    listener_;
+	std::optional<uprotocol::utils::callbacks::CallerHandle<
+	    void, uprotocol::v1::UMessage const&>>
+	    cleanup_listener_;
+	std::optional<uprotocol::v1::UUri> source_filter_;
+	v1::UUri sink_filter_;
+	v1::UMessage message_;
 
 private:
 	[[nodiscard]] v1::UStatus sendImpl(const v1::UMessage& message) override {
 		v1::UStatus retval;
-		mock_info.message = message;
-		mock_info.send_count++;
-		return mock_info.send_status;
+		message_ = message;
+		send_count_++;
+		return send_status_;
 	}
 
 	[[nodiscard]] v1::UStatus registerListenerImpl(
 	    const v1::UUri& sink_filter, CallableConn&& listener,
 	    std::optional<v1::UUri>&& source_filter) override {
-		mock_info.listener = listener;
-		mock_info.source_filter = source_filter;
-		mock_info.sink_filter = sink_filter;
+		listener_ = listener;
+		source_filter_ = source_filter;
+		sink_filter_ = sink_filter;
 		v1::UStatus retval;
 		retval.set_code(v1::UCode::OK);
 		return retval;
 	}
 
 	void cleanupListener(CallableConn listener) override {
-		mock_info.cleanupListener = listener;
+		cleanup_listener_ = listener;
 	}
 };
-
-// uprotocol::test::UTransportMockInfo __attribute__((weak)) UTransportMock::mock_info = uprotocol::test::UTransportMockInfo();
-uprotocol::test::UTransportMockInfo UTransportMock::mock_info = uprotocol::test::UTransportMockInfo();
 
 };  // namespace uprotocol::test
 

--- a/test/include/UTransportMock.h
+++ b/test/include/UTransportMock.h
@@ -61,6 +61,11 @@ public:
 
 	~UTransportMock() { mock_info.deinit_passed = true; }
 
+	static UTransportMockInfo& singleton()
+	{
+		return mock_info;
+	}
+
 private:
 	[[nodiscard]] v1::UStatus sendImpl(const v1::UMessage& message) override {
 		v1::UStatus retval;
@@ -84,6 +89,9 @@ private:
 		mock_info.cleanupListener = listener;
 	}
 };
+
+// uprotocol::test::UTransportMockInfo __attribute__((weak)) UTransportMock::mock_info = uprotocol::test::UTransportMockInfo();
+uprotocol::test::UTransportMockInfo UTransportMock::mock_info = uprotocol::test::UTransportMockInfo();
 
 };  // namespace uprotocol::test
 


### PR DESCRIPTION
init/deinit tesing has been removed, and so the UTransportMock no longer needs to contain a static member for checking for deinitialization. Furthermore, the memory leak detector was removed, since this is supposed to be cover elsewhere by valgrind.