### PR TITLE
UMessage: Add more notification UUri checking

### DIFF
--- a/include/up-cpp/datamodel/validator/UUri.h
+++ b/include/up-cpp/datamodel/validator/UUri.h
@@ -88,11 +88,17 @@ using ValidationResult = std::tuple<bool, std::optional<Reason>>;
 /// resource_id must be in the range [0x8000, 0xFFFE].
 [[nodiscard]] ValidationResult isValidPublishTopic(const v1::UUri&);
 
-/// @brief Checks if UUri is valid for notification message.
+/// @brief Checks if UUri is valid for notification source.
 ///
 /// The UUri must not be blank, no field can be a wildcard, and
 /// resource_id must be in the range [0x8000, 0xFFFE].
-[[nodiscard]] ValidationResult isValidNotification(const v1::UUri&);
+[[nodiscard]] ValidationResult isValidNotificationSource(const v1::UUri&);
+
+/// @brief Checks if UUri is valid for notification sink.
+///
+/// The UUri must not be blank, no field can be a wildcard, and
+/// resource_id must be 0.
+[[nodiscard]] ValidationResult isValidNotificationSink(const v1::UUri&);
 
 /// @brief Checks if UUri is valid as a subscription to a published topic or
 ///        as a source filter when subscribing to a notification.

--- a/src/datamodel/builder/UMessage.cpp
+++ b/src/datamodel/builder/UMessage.cpp
@@ -34,13 +34,13 @@ UMessageBuilder UMessageBuilder::publish(v1::UUri&& topic) {
 
 UMessageBuilder UMessageBuilder::notification(v1::UUri&& source,
                                               v1::UUri&& sink) {
-	auto [srcOk, srcReason] = UriValidator::isValidNotification(source);
+	auto [srcOk, srcReason] = UriValidator::isValidNotificationSource(source);
 	if (!srcOk) {
 		throw UriValidator::InvalidUUri(
 		    "Source URI is not a valid URI |  " +
 		    std::string(UriValidator::message(*srcReason)));
 	}
-	auto [sinkOk, sinkReason] = UriValidator::isValid(sink);
+	auto [sinkOk, sinkReason] = UriValidator::isValidNotificationSink(sink);
 	if (!sinkOk) {
 		throw UriValidator::InvalidUUri(
 		    "Sink URI is not a valid URI |  " +

--- a/src/datamodel/validator/UMessage.cpp
+++ b/src/datamodel/validator/UMessage.cpp
@@ -327,7 +327,7 @@ ValidationResult isValidNotification(const v1::UMessage& umessage) {
 
 	{
 		auto [valid, reason] =
-		    uri::isValidNotification(umessage.attributes().source());
+		    uri::isValidNotificationSource(umessage.attributes().source());
 		if (!valid) {
 			return {false, Reason::BAD_SOURCE_URI};
 		}
@@ -335,7 +335,7 @@ ValidationResult isValidNotification(const v1::UMessage& umessage) {
 
 	{
 		auto [valid, reason] =
-		    uri::isValidNotification(umessage.attributes().sink());
+		    uri::isValidNotificationSink(umessage.attributes().sink());
 		if (!valid) {
 			return {false, Reason::BAD_SINK_URI};
 		}

--- a/src/datamodel/validator/UUri.cpp
+++ b/src/datamodel/validator/UUri.cpp
@@ -75,7 +75,14 @@ ValidationResult isValid(const v1::UUri& uuri) {
 		}
 	}
 
-	return isValidNotification(uuri);
+	{
+		auto [valid, reason] = isValidNotificationSource(uuri);
+		if (valid) {
+			return {true, std::nullopt};
+		}
+	}
+
+	return isValidNotificationSink(uuri);
 }
 
 ValidationResult isValidRpcMethod(const v1::UUri& uuri) {
@@ -125,17 +132,26 @@ ValidationResult isValidPublishTopic(const v1::UUri& uuri) {
 	return {true, std::nullopt};
 }
 
-ValidationResult isValidNotification(const v1::UUri& uuri) {
+ValidationResult isValidNotificationSource(const v1::UUri& uuri) {
 	// disallow wildcards
 	if (uses_wildcards(uuri)) {
 		return {false, Reason::DISALLOWED_WILDCARD};
 	}
 
-	if ((uuri.resource_id() < 0x8000) && (uuri.resource_id() != 0)) {
+	if ((uuri.resource_id() < 0x8000) || (uuri.resource_id() > 0xFFFF)) {
 		return {false, Reason::BAD_RESOURCE_ID};
 	}
 
-	if (uuri.resource_id() > 0xFFFF) {
+	return {true, std::nullopt};
+}
+
+ValidationResult isValidNotificationSink(const v1::UUri& uuri) {
+	// disallow wildcards
+	if (uses_wildcards(uuri)) {
+		return {false, Reason::DISALLOWED_WILDCARD};
+	}
+
+	if (uuri.resource_id() != 0) {
 		return {false, Reason::BAD_RESOURCE_ID};
 	}
 

--- a/test/coverage/communication/NotificationSourceTest.cpp
+++ b/test/coverage/communication/NotificationSourceTest.cpp
@@ -45,6 +45,9 @@ protected:
 		transportMock_ =
 		    std::make_shared<uprotocol::test::UTransportMock>(source_);
 
+		source_.set_resource_id(0x8101);
+		sink_.set_resource_id(0x0);
+
 		format_ = UPayloadFormat::UPAYLOAD_FORMAT_TEXT;
 		priority_ = UPriority::UPRIORITY_CS1;
 		ttl_ = std::chrono::milliseconds(1000);

--- a/test/coverage/datamodel/UMessageBuilderTest.cpp
+++ b/test/coverage/datamodel/UMessageBuilderTest.cpp
@@ -74,7 +74,7 @@ protected:
 		sink_.set_authority_name("10.0.0.2");
 		sink_.set_ue_id(0x00011102);
 		sink_.set_ue_version_major(0xF9);
-		sink_.set_resource_id(0x8102);
+		sink_.set_resource_id(0);
 
 		method_.set_authority_name("10.0.0.3");
 		method_.set_ue_id(0x00011103);

--- a/test/coverage/datamodel/UMessageValidatorTest.cpp
+++ b/test/coverage/datamodel/UMessageValidatorTest.cpp
@@ -660,7 +660,7 @@ TEST_F(TestUMessageValidator, ValidPublish) {
 
 TEST_F(TestUMessageValidator, ValidNotification) {
 	source_.set_resource_id(0x8001);
-	sink_.set_resource_id(0xFFFE);
+	sink_.set_resource_id(0);
 
 	{
 		// test common attributes for any message
@@ -871,7 +871,7 @@ TEST_F(TestUMessageValidator, IsValid) {
 		auto source = source_;
 		auto sink = sink_;
 		source.set_resource_id(0x8001);
-		sink.set_resource_id(0xFFFE);
+		sink.set_resource_id(0);
 
 		auto attributes = fakeNotification(source, sink);
 		auto umessage = build(attributes);

--- a/test/coverage/datamodel/UUriValidatorTest.cpp
+++ b/test/coverage/datamodel/UUriValidatorTest.cpp
@@ -309,7 +309,7 @@ TEST_F(TestUUriValidator, ValidPublishTopic) {
 	}
 }
 
-TEST_F(TestUUriValidator, ValidNotification) {
+TEST_F(TestUUriValidator, ValidNotificationSource) {
 	auto getUuri = []() {
 		uprotocol::v1::UUri uuri;
 		uuri.set_authority_name(AUTHORITY_NAME);
@@ -328,7 +328,7 @@ TEST_F(TestUUriValidator, ValidNotification) {
 
 	{
 		auto uuri = getUuri();
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSource(uuri);
 		EXPECT_TRUE(valid);
 		EXPECT_FALSE(reason.has_value());
 		EXPECT_FALSE(uses_wildcards(uuri));
@@ -337,7 +337,7 @@ TEST_F(TestUUriValidator, ValidNotification) {
 	{
 		auto uuri = getUuri();
 		uuri.set_authority_name("");
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSource(uuri);
 		EXPECT_TRUE(valid);
 		EXPECT_FALSE(reason.has_value());
 	}
@@ -345,7 +345,7 @@ TEST_F(TestUUriValidator, ValidNotification) {
 	{
 		auto uuri = getUuri();
 		uuri.set_resource_id(0xFFFF);
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSource(uuri);
 		EXPECT_FALSE(valid);
 		EXPECT_TRUE(reason == Reason::DISALLOWED_WILDCARD);
 	}
@@ -353,7 +353,7 @@ TEST_F(TestUUriValidator, ValidNotification) {
 	{
 		auto uuri = getUuri();
 		uuri.set_resource_id(1);
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSource(uuri);
 		EXPECT_FALSE(valid);
 		EXPECT_TRUE(reason == Reason::BAD_RESOURCE_ID);
 	}
@@ -361,17 +361,59 @@ TEST_F(TestUUriValidator, ValidNotification) {
 	{
 		auto uuri = getUuri();
 		uuri.set_resource_id(0x10000);
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSource(uuri);
 		EXPECT_FALSE(valid);
 		EXPECT_TRUE(reason == Reason::BAD_RESOURCE_ID);
+	}
+}
+
+TEST_F(TestUUriValidator, ValidNotificationSink) {
+	auto getUuri = []() {
+		uprotocol::v1::UUri uuri;
+		uuri.set_authority_name(AUTHORITY_NAME);
+		uuri.set_ue_id(0x00010001);
+		uuri.set_ue_version_major(1);
+		uuri.set_resource_id(0);
+		return uuri;
+	};
+
+	{
+		auto uuri = getUuri();
+		auto [valid, reason] = isValid(uuri);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
 	}
 
 	{
 		auto uuri = getUuri();
-		uuri.set_resource_id(0);
-		auto [valid, reason] = isValidNotification(uuri);
+		auto [valid, reason] = isValidNotificationSink(uuri);
 		EXPECT_TRUE(valid);
 		EXPECT_FALSE(reason.has_value());
+		EXPECT_FALSE(uses_wildcards(uuri));
+	}
+
+	{
+		auto uuri = getUuri();
+		uuri.set_authority_name("");
+		auto [valid, reason] = isValidNotificationSink(uuri);
+		EXPECT_TRUE(valid);
+		EXPECT_FALSE(reason.has_value());
+	}
+
+	{
+		auto uuri = getUuri();
+		uuri.set_resource_id(0xFFFF);
+		auto [valid, reason] = isValidNotificationSink(uuri);
+		EXPECT_FALSE(valid);
+		EXPECT_TRUE(reason == Reason::DISALLOWED_WILDCARD);
+	}
+
+	{
+		auto uuri = getUuri();
+		uuri.set_resource_id(1);
+		auto [valid, reason] = isValidNotificationSink(uuri);
+		EXPECT_FALSE(valid);
+		EXPECT_TRUE(reason == Reason::BAD_RESOURCE_ID);
 	}
 }
 


### PR DESCRIPTION
Split the uuri::isValidNotification function into two functions, one for the source and one for sink and update appropriate tests/files.

This PR is intended to close issue #188 