### PR TITLE
Implementation of RpcClient

### DIFF
--- a/include/up-cpp/communication/RpcClient.h
+++ b/include/up-cpp/communication/RpcClient.h
@@ -54,18 +54,10 @@ struct RpcClient {
 	                   std::optional<uint32_t> permission_level = {},
 	                   std::optional<std::string> token = {});
 
-	/// @brief A status code that can be returned in the response message's
-	///        attributes.
-	using Commstatus = v1::UCode;
-
-	/// @brief Represents the combined status possibilities for transport and
-	///        uProtocol network communications.
-	using Status = std::variant<v1::UStatus, Commstatus>;
-
-	/// @brief Contains either a UMessage (when successful) or a UStatus /
-	///        Commstatus when an error occurred. Commstatus would be set based
+	/// @brief Contains either a UMessage (when successful) or a UStatus
+	///        when an error occurred. The UStatus could be set based
 	///        on the commstatus attributes field in any returned messages.
-	using MessageOrStatus = utils::Expected<v1::UMessage, Status>;
+	using MessageOrStatus = utils::Expected<v1::UMessage, v1::UStatus>;
 
 	/// @brief Callback connections for callbacks passed to invokeMethod()
 	using Connection = utils::callbacks::Connection<void, MessageOrStatus&&>;
@@ -116,7 +108,8 @@ struct RpcClient {
 	///       * A UStatus with a DEADLINE_EXCEEDED code if no response was
 	///         received before the request expired (based on request TTL).
 	///       * A UStatus with the value returned by UTransport::send().
-	///       * A Commstatus as received in the response message (if not OK).
+	///       * A UStatus based on the commstatus received in the response
+	///         message (if not OK).
 	///       * A UMessage containing the response from the RPC target.
 	[[nodiscard]] InvokeHandle invokeMethod(datamodel::builder::Payload&&,
 	                                        Callback&&);
@@ -132,7 +125,8 @@ struct RpcClient {
 	///          * A UStatus with a DEADLINE_EXCEEDED code if no response was
 	///            received before the request expired (based on request TTL).
 	///          * A UStatus with the value returned by UTransport::send().
-	///          * A Commstatus as received in the response message (if not OK).
+	///          * A UStatus based on the commstatus received in the response
+	///            message (if not OK).
 	///          * A UMessage containing the response from the RPC target.
 	[[nodiscard]] InvokeFuture invokeMethod(datamodel::builder::Payload&&);
 
@@ -147,7 +141,8 @@ struct RpcClient {
 	///       * A UStatus with a DEADLINE_EXCEEDED code if no response was
 	///         received before the request expired (based on request TTL).
 	///       * A UStatus with the value returned by UTransport::send().
-	///       * A Commstatus as received in the response message (if not OK).
+	///       * A UStatus based on the commstatus received in the response
+	///         message (if not OK).
 	///       * A UMessage containing the response from the RPC target.
 	[[nodiscard]] InvokeHandle invokeMethod(Callback&&);
 
@@ -162,7 +157,8 @@ struct RpcClient {
 	///          * A UStatus with a DEADLINE_EXCEEDED code if no response was
 	///            received before the request expired (based on request TTL).
 	///          * A UStatus with the value returned by UTransport::send().
-	///          * A Commstatus as received in the response message (if not OK).
+	///          * A UStatus based on the commstatus received in the response
+	///            message (if not OK).
 	///          * A UMessage containing the response from the RPC target.
 	[[nodiscard]] InvokeFuture invokeMethod();
 

--- a/src/communication/RpcClient.cpp
+++ b/src/communication/RpcClient.cpp
@@ -11,6 +11,8 @@
 
 #include "up-cpp/communication/RpcClient.h"
 
+#include <google/protobuf/util/message_differencer.h>
+
 #include <chrono>
 #include <queue>
 
@@ -21,15 +23,19 @@ using namespace uprotocol;
 
 struct PendingRequest {
 	std::chrono::steady_clock::time_point when_expire;
+	transport::UTransport::ListenHandle response_listener;
 	std::function<void(communication::RpcClient::Status)> expire;
 	size_t instance_id;
 
-	auto operator<(const PendingRequest& other) const;
+	auto operator>(const PendingRequest& other) const;
 };
 
-struct ScrubablePendingQueue : public std::priority_queue<PendingRequest> {
+struct ScrubablePendingQueue
+    : public std::priority_queue<PendingRequest, std::vector<PendingRequest>,
+                                 std::greater<PendingRequest>> {
 	~ScrubablePendingQueue();
 	auto scrub(size_t instance_id);
+	PendingRequest& top();
 };
 
 struct ExpireWorker {
@@ -56,10 +62,19 @@ namespace uprotocol::communication {
 struct RpcClient::ExpireService {
 	ExpireService() : instance_id_(next_instance_id++) {}
 
-	~ExpireService() {}
+	~ExpireService() { worker.scrub(instance_id_); }
 
 	void enqueue(std::chrono::steady_clock::time_point when_expire,
-	             std::function<void(RpcClient::Status)> expire) {}
+	             transport::UTransport::ListenHandle&& response_listener,
+	             std::function<void(RpcClient::Status)> expire) {
+		detail::PendingRequest pending{
+		    .when_expire = when_expire,
+		    .response_listener = std::move(response_listener),
+		    .expire = std::move(expire),
+		    .instance_id = instance_id_};
+
+		worker.enqueue(std::move(pending));
+	}
 
 private:
 	static inline std::atomic<size_t> next_instance_id{0};
@@ -75,29 +90,113 @@ RpcClient::RpcClient(std::shared_ptr<transport::UTransport> transport,
                      std::optional<uint32_t> permission_level,
                      std::optional<std::string> token)
     : transport_(transport),
+      ttl_(ttl),
       builder_(datamodel::builder::UMessageBuilder::request(
           std::move(method), v1::UUri(transport_->getDefaultSource()), priority,
-          ttl)),
-      expire_service_(std::make_unique<ExpireService>()) {}
+          ttl_)),
+      expire_service_(std::make_unique<ExpireService>()) {
+	if (payload_format) {
+		builder_.withPayloadFormat(*payload_format);
+	}
 
-void RpcClient::invokeMethod(v1::UMessage&& request, Callback&& callback) {}
+	if (permission_level) {
+		builder_.withPermissionLevel(*permission_level);
+	}
+
+	if (token) {
+		builder_.withToken(*token);
+	}
+}
+
+void RpcClient::invokeMethod(v1::UMessage&& request, Callback&& callback) {
+	auto when_expire = std::chrono::steady_clock::now() + ttl_;
+	auto reqid = request.attributes().id();
+	// Used to ensure that, no matter what, the callback is only called once
+	auto callback_once = std::make_shared<std::once_flag>();
+
+	///////////////////////////////////////////////////////////////////////////
+	// Wraps the callback to handle receive filtering and commstatus checking
+	auto wrapper = [callback, reqid = std::move(reqid),
+	                callback_once](const v1::UMessage& m) {
+		using MsgDiff = google::protobuf::util::MessageDifferencer;
+		if (MsgDiff::Equals(m.attributes().reqid(), reqid)) {
+			if (m.attributes().commstatus() == v1::UCode::OK) {
+				std::call_once(*callback_once,
+				               [&callback, &m]() { callback(m); });
+			} else {
+				std::call_once(*callback_once, [&callback, &m]() {
+					callback(
+					    utils::Unexpected<Status>(m.attributes().commstatus()));
+				});
+			}
+		}
+	};
+	///////////////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////////////
+	// Called locally when the request has expired. Will be handed off to the
+	// expiration monitoring service.
+	auto expire = [callback = std::move(callback), callback_once](
+	                  std::variant<v1::UStatus, Commstatus>&& reason) {
+		std::call_once(*callback_once, [callback = std::move(callback),
+		                                reason = std::move(reason)]() {
+			callback(utils::Unexpected<Status>(std::move(reason)));
+		});
+	};
+	///////////////////////////////////////////////////////////////////////////
+
+	auto maybe_handle = transport_->registerListener(
+	    request.attributes().source(), std::move(wrapper),
+	    request.attributes().sink());
+
+	if (!maybe_handle) {
+		expire(maybe_handle.error());
+	} else {
+		auto send_result = transport_->send(request);
+		if (send_result.code() != v1::UCode::OK) {
+			expire(send_result);
+		}
+
+		expire_service_->enqueue(when_expire, std::move(maybe_handle).value(),
+		                         std::move(expire));
+	}
+}
 
 void RpcClient::invokeMethod(datamodel::builder::Payload&& payload,
-                             Callback&& callback) {}
+                             Callback&& callback) {
+	invokeMethod(builder_.build(std::move(payload)), std::move(callback));
+}
 
-void RpcClient::invokeMethod(Callback&& callback) {}
+void RpcClient::invokeMethod(Callback&& callback) {
+	invokeMethod(builder_.build(), std::move(callback));
+}
 
 std::future<RpcClient::MessageOrStatus> RpcClient::invokeMethod(
     datamodel::builder::Payload&& payload) {
-	std::promise<MessageOrStatus> promise;
-	auto future = promise.get_future();
+	// Note: functors need to be copy constructable. We work around this by
+	// wrapping the promise in a shared_ptr. Unique access to it will be
+	// assured by the implementation at the core of invokeMethod - it only
+	// allows exactly one call to the callback via std::call_once.
+	auto promise = std::make_shared<std::promise<MessageOrStatus>>();
+	auto future = promise->get_future();
+	invokeMethod(std::move(payload),
+	             [promise](MessageOrStatus maybe_message) mutable {
+		             promise->set_value(maybe_message);
+	             });
 
 	return future;
 }
 
 std::future<RpcClient::MessageOrStatus> RpcClient::invokeMethod() {
-	std::promise<MessageOrStatus> promise;
-	auto future = promise.get_future();
+	// Note: functors need to be copy constructable. We work around this by
+	// wrapping the promise in a shared_ptr. Unique access to it will be
+	// assured by the implementation at the core of invokeMethod - it only
+	// allows exactly one call to the callback via std::call_once.
+	auto promise = std::make_shared<std::promise<MessageOrStatus>>();
+	auto future = promise->get_future();
+	invokeMethod([promise](MessageOrStatus maybe_message) mutable {
+		promise->set_value(maybe_message);
+	});
 
 	return future;
 }
@@ -114,23 +213,145 @@ namespace detail {
 using namespace uprotocol;
 using namespace std::chrono_literals;
 
-auto PendingRequest::operator<(const PendingRequest& other) const {
-	return when_expire < other.when_expire;
+auto PendingRequest::operator>(const PendingRequest& other) const {
+	return when_expire > other.when_expire;
 }
 
-ScrubablePendingQueue::~ScrubablePendingQueue() {}
+ScrubablePendingQueue::~ScrubablePendingQueue() {
+	const v1::UStatus cancel_reason = []() {
+		v1::UStatus reason;
+		reason.set_code(v1::UCode::CANCELLED);
+		reason.set_message("ExpireWorker shutting down");
+		return reason;
+	}();
 
-auto ScrubablePendingQueue::scrub(size_t instance_id) {}
+	for (auto& pending : c) {
+		pending.expire(cancel_reason);
+	}
+}
 
-ExpireWorker::ExpireWorker() {}
+auto ScrubablePendingQueue::scrub(size_t instance_id) {
+	// Collect all the expire lambdas so they can be called without the
+	// lock held.
+	std::vector<std::function<void(communication::RpcClient::Status)>>
+	    all_expired;
 
-ExpireWorker::~ExpireWorker() {}
+	c.erase(
+	    std::remove_if(c.begin(), c.end(),
+	                   [instance_id, &all_expired](const PendingRequest& p) {
+		                   if (instance_id == p.instance_id) {
+			                   all_expired.push_back(p.expire);
+			                   return true;
+		                   }
+		                   return false;
+	                   }),
+	    c.end());
 
-void ExpireWorker::enqueue(PendingRequest&& request) {}
+	// TODO - is there a better way to shrink the internal container?
+	// Maybe instead we should enforce a capacity limit
+	constexpr size_t capacity_shrink_threshold = 16;
+	if ((c.capacity() > capacity_shrink_threshold) &&
+	    (c.size() < c.capacity() / 2)) {
+		c.shrink_to_fit();
+	}
 
-void ExpireWorker::scrub(size_t instance_id) {}
+	return all_expired;
+}
 
-void ExpireWorker::doWork() {}
+// Exposing non-const version so the listen handle can be moved out
+PendingRequest& ScrubablePendingQueue::top() { return c.front(); }
+
+ExpireWorker::ExpireWorker() {
+	worker_ = std::thread([this]() { doWork(); });
+}
+
+ExpireWorker::~ExpireWorker() {
+	stop_ = true;
+	{
+		std::lock_guard lock(pending_mtx_);
+		wake_worker_.notify_one();
+	}
+	worker_.join();
+}
+
+void ExpireWorker::enqueue(PendingRequest&& pending) {
+	std::lock_guard lock(pending_mtx_);
+	pending_.emplace(std::move(pending));
+	wake_worker_.notify_one();
+}
+
+void ExpireWorker::scrub(size_t instance_id) {
+	std::vector<std::function<void(communication::RpcClient::Status)>>
+	    all_expired;
+	{
+		std::lock_guard lock(pending_mtx_);
+		all_expired = pending_.scrub(instance_id);
+		wake_worker_.notify_one();
+	}
+
+	static const v1::UStatus cancel_reason = []() {
+		v1::UStatus reason;
+		reason.set_code(v1::UCode::CANCELLED);
+		reason.set_message("RpcClient for this request was discarded");
+		return reason;
+	}();
+
+	for (auto& expire : all_expired) {
+		expire(cancel_reason);
+	}
+}
+
+void ExpireWorker::doWork() {
+	while (!stop_) {
+		const auto now = std::chrono::steady_clock::now();
+		std::optional<decltype(PendingRequest::expire)> maybe_expire;
+
+		{
+			transport::UTransport::ListenHandle expired_handle;
+			std::lock_guard lock(pending_mtx_);
+			if (!pending_.empty()) {
+				const auto when_expire = pending_.top().when_expire;
+				if (when_expire <= now) {
+					maybe_expire = pending_.top().expire;
+					expired_handle =
+					    std::move(pending_.top().response_listener);
+					pending_.pop();
+				}
+			}
+		}
+
+		if (maybe_expire) {
+			auto& expire = *maybe_expire;
+
+			static const v1::UStatus expire_reason = []() {
+				v1::UStatus reason;
+				reason.set_code(v1::UCode::DEADLINE_EXCEEDED);
+				reason.set_message("Request expired before response received");
+				return reason;
+			}();
+
+			expire(expire_reason);
+
+		} else {
+			std::unique_lock lock(pending_mtx_);
+			if (pending_.empty()) {
+				wake_worker_.wait(
+				    lock, [this]() { return stop_ || !pending_.empty(); });
+			} else {
+				auto wake_when = pending_.top().when_expire;
+				wake_worker_.wait_until(lock, wake_when, [this, &wake_when]() {
+					auto when_next_wake = wake_when;
+					if (!pending_.empty()) {
+						when_next_wake =
+						    std::min(wake_when, pending_.top().when_expire);
+					}
+					return stop_ ||
+					       (std::chrono::steady_clock::now() >= when_next_wake);
+				});
+			}
+		}
+	}
+}
 
 }  // namespace detail
 }  // namespace

--- a/src/communication/RpcClient.cpp
+++ b/src/communication/RpcClient.cpp
@@ -10,3 +10,127 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "up-cpp/communication/RpcClient.h"
+
+#include <chrono>
+#include <queue>
+
+namespace {
+namespace detail {
+
+using namespace uprotocol;
+
+struct PendingRequest {
+	std::chrono::steady_clock::time_point when_expire;
+	std::function<void(communication::RpcClient::Status)> expire;
+	size_t instance_id;
+
+	auto operator<(const PendingRequest& other) const;
+};
+
+struct ScrubablePendingQueue : public std::priority_queue<PendingRequest> {
+	~ScrubablePendingQueue();
+	auto scrub(size_t instance_id);
+};
+
+struct ExpireWorker {
+	ExpireWorker();
+	~ExpireWorker();
+	void enqueue(PendingRequest&& request);
+	void scrub(size_t instance_id);
+	void doWork();
+
+private:
+	std::mutex pending_mtx_;
+	ScrubablePendingQueue pending_;
+	std::thread worker_;
+	std::atomic<bool> stop_{false};
+	std::condition_variable wake_worker_;
+};
+
+}  // namespace detail
+}  // namespace
+
+namespace uprotocol::communication {
+
+////////////////////////////////////////////////////////////////////////////////
+struct RpcClient::ExpireService {
+	ExpireService() : instance_id_(next_instance_id++) {}
+
+	~ExpireService() {}
+
+	void enqueue(std::chrono::steady_clock::time_point when_expire,
+	             std::function<void(RpcClient::Status)> expire) {}
+
+private:
+	static inline std::atomic<size_t> next_instance_id{0};
+	static inline detail::ExpireWorker worker;
+	size_t instance_id_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+RpcClient::RpcClient(std::shared_ptr<transport::UTransport> transport,
+                     v1::UUri&& method, v1::UPriority priority,
+                     std::chrono::milliseconds ttl,
+                     std::optional<v1::UPayloadFormat> payload_format,
+                     std::optional<uint32_t> permission_level,
+                     std::optional<std::string> token)
+    : transport_(transport),
+      builder_(datamodel::builder::UMessageBuilder::request(
+          std::move(method), v1::UUri(transport_->getDefaultSource()), priority,
+          ttl)),
+      expire_service_(std::make_unique<ExpireService>()) {}
+
+void RpcClient::invokeMethod(v1::UMessage&& request, Callback&& callback) {}
+
+void RpcClient::invokeMethod(datamodel::builder::Payload&& payload,
+                             Callback&& callback) {}
+
+void RpcClient::invokeMethod(Callback&& callback) {}
+
+std::future<RpcClient::MessageOrStatus> RpcClient::invokeMethod(
+    datamodel::builder::Payload&& payload) {
+	std::promise<MessageOrStatus> promise;
+	auto future = promise.get_future();
+
+	return future;
+}
+
+std::future<RpcClient::MessageOrStatus> RpcClient::invokeMethod() {
+	std::promise<MessageOrStatus> promise;
+	auto future = promise.get_future();
+
+	return future;
+}
+
+RpcClient::RpcClient(RpcClient&&) = default;
+RpcClient::~RpcClient() = default;
+
+}  // namespace uprotocol::communication
+
+///////////////////////////////////////////////////////////////////////////////
+namespace {
+namespace detail {
+
+using namespace uprotocol;
+using namespace std::chrono_literals;
+
+auto PendingRequest::operator<(const PendingRequest& other) const {
+	return when_expire < other.when_expire;
+}
+
+ScrubablePendingQueue::~ScrubablePendingQueue() {}
+
+auto ScrubablePendingQueue::scrub(size_t instance_id) {}
+
+ExpireWorker::ExpireWorker() {}
+
+ExpireWorker::~ExpireWorker() {}
+
+void ExpireWorker::enqueue(PendingRequest&& request) {}
+
+void ExpireWorker::scrub(size_t instance_id) {}
+
+void ExpireWorker::doWork() {}
+
+}  // namespace detail
+}  // namespace

--- a/test/coverage/communication/RpcClientTest.cpp
+++ b/test/coverage/communication/RpcClientTest.cpp
@@ -9,32 +9,1333 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 #include <up-cpp/communication/RpcClient.h>
+#include <up-cpp/datamodel/builder/Payload.h>
+#include <up-cpp/datamodel/builder/Uuid.h>
+#include <up-cpp/datamodel/serializer/Uuid.h>
+#include <up-cpp/datamodel/validator/UMessage.h>
+#include <up-cpp/datamodel/validator/UUri.h>
+
+#include <list>
+#include <thread>
 
 #include "UTransportMock.h"
 
+using namespace std::chrono_literals;
+
 namespace {
 
-class TestFixture : public testing::Test {
+bool operator==(const uprotocol::v1::UUri& lhs,
+                const uprotocol::v1::UUri& rhs) {
+	using namespace google::protobuf::util;
+	return MessageDifferencer::Equals(lhs, rhs);
+}
+
+bool operator==(const uprotocol::v1::UMessage& lhs,
+                const uprotocol::v1::UMessage& rhs) {
+	using namespace google::protobuf::util;
+	return MessageDifferencer::Equals(lhs, rhs);
+}
+
+bool operator==(const uprotocol::v1::UStatus& lhs,
+                const uprotocol::v1::UStatus& rhs) {
+	using namespace google::protobuf::util;
+	return MessageDifferencer::Equals(lhs, rhs);
+}
+
+bool operator==(const uprotocol::v1::UStatus& lhs,
+                const uprotocol::v1::UCode& rhs) {
+	return lhs.code() == rhs;
+}
+
+class RpcClientTest : public testing::Test {
 protected:
 	// Run once per TEST_F.
 	// Used to set up clean environments per test.
-	void SetUp() override {}
+	void SetUp() override {
+		transport_ = std::make_shared<uprotocol::test::UTransportMock>(
+		    defaultSourceUri());
+	}
+
 	void TearDown() override {}
 
 	// Run once per execution of the test application.
 	// Used for setup of all tests. Has access to this instance.
-	TestFixture() = default;
-	~TestFixture() = default;
+	RpcClientTest() = default;
+	~RpcClientTest() = default;
 
 	// Run once per execution of the test application.
 	// Used only for global setup outside of tests.
 	static void SetUpTestSuite() {}
-	static void TearDownTestSuite() {}
+	static void TearDownTestSuite() {
+		// Gives clean valgrind output. Protobufs isn't losing track of the
+		// memory, but it also doesn't automatically free its allocated memory
+		// when the application exits.
+		google::protobuf::ShutdownProtobufLibrary();
+	}
+
+	static uprotocol::v1::UUri methodUri(const std::string& auth = "TestAuth",
+	                                     uint16_t ue_id = 0x8000,
+	                                     uint16_t ue_instance = 1,
+	                                     uint16_t ue_version_major = 1,
+	                                     uint16_t resource_id = 1) {
+		uprotocol::v1::UUri uri;
+		uri.set_authority_name(auth);
+		uri.set_ue_id(static_cast<uint32_t>(ue_instance) << 16 |
+		              static_cast<uint32_t>(ue_id));
+		uri.set_ue_version_major(ue_version_major);
+		uri.set_resource_id(resource_id);
+		return uri;
+	}
+
+	static uprotocol::v1::UUri defaultSourceUri() {
+		auto uri = methodUri();
+		uri.set_resource_id(0);
+		return uri;
+	}
+
+	void validateLastRequest(size_t expected_send_count) {
+		EXPECT_TRUE(transport_->listener_);
+		EXPECT_TRUE(transport_->sink_filter_ == defaultSourceUri());
+		EXPECT_TRUE(transport_->source_filter_);
+		if (transport_->source_filter_) {
+			EXPECT_TRUE(*(transport_->source_filter_) == methodUri());
+		}
+		EXPECT_EQ(transport_->send_count_, expected_send_count);
+		using namespace uprotocol::datamodel::validator;
+		auto [valid_request, _] =
+		    message::isValidRpcRequest(transport_->message_);
+		EXPECT_TRUE(valid_request);
+	}
+
+	std::shared_ptr<uprotocol::test::UTransportMock> transport_;
 };
 
-// TODO replace
-TEST_F(TestFixture, SomeTestName) {}
+template <typename StatusT, typename ExpectedT>
+void checkErrorResponse(
+    const uprotocol::communication::RpcClient::MessageOrStatus& maybe_response,
+    ExpectedT expected_status) {
+	EXPECT_FALSE(maybe_response);
+	if (!maybe_response) {
+		auto& some_status = maybe_response.error();
+		EXPECT_TRUE(std::holds_alternative<StatusT>(some_status));
+		if (std::holds_alternative<StatusT>(some_status)) {
+			auto& status = std::get<StatusT>(some_status);
+			EXPECT_TRUE(status == expected_status);
+		}
+	}
+}
+
+uprotocol::datamodel::builder::Payload fakePayload() {
+	using namespace uprotocol::datamodel;
+
+	auto uuid = builder::UuidBuilder::getBuilder();
+	auto uuid_str = serializer::uuid::AsString::serialize(uuid.build());
+
+	return builder::Payload(
+	    std::move(uuid_str),
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_TEXT);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Construction
+TEST_F(RpcClientTest, CanConstructWithoutExceptions) {
+	// Base parameters
+	EXPECT_NO_THROW(auto client = uprotocol::communication::RpcClient(
+	                    transport_, methodUri(),
+	                    uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms););
+
+	// Optional format
+	EXPECT_NO_THROW(auto client = uprotocol::communication::RpcClient(
+	                    transport_, methodUri(),
+	                    uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	                    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_JSON););
+
+	// Optional permission level
+	EXPECT_NO_THROW(auto client = uprotocol::communication::RpcClient(
+	                    transport_, methodUri(),
+	                    uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms, {}, 9););
+
+	// Optional permission level
+	EXPECT_NO_THROW(auto client = uprotocol::communication::RpcClient(
+	                    transport_, methodUri(),
+	                    uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms, {}, {},
+	                    "Some token"););
+}
+
+TEST_F(RpcClientTest, ExceptionThrownWithInvalidConstructorArguments) {
+	// Bad method URI
+	EXPECT_THROW(auto uri = methodUri(); uri.set_resource_id(0);
+	             auto client = uprotocol::communication::RpcClient(
+	                 transport_, std::move(uri),
+	                 uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+	             , uprotocol::datamodel::validator::uri::InvalidUUri);
+
+	// Bad priority
+	EXPECT_THROW(auto client = uprotocol::communication::RpcClient(
+	                 transport_, methodUri(),
+	                 uprotocol::v1::UPriority::UPRIORITY_CS3, 10ms);
+	             , std::out_of_range);
+
+	// Bad ttl
+	EXPECT_THROW(auto client = uprotocol::communication::RpcClient(
+	                 transport_, methodUri(),
+	                 uprotocol::v1::UPriority::UPRIORITY_CS4, 0ms);
+	             , std::out_of_range);
+
+	// Bad payload format
+	EXPECT_THROW(
+	    auto client = uprotocol::communication::RpcClient(
+	        transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+	        10ms, static_cast<uprotocol::v1::UPayloadFormat>(-1));
+	    , std::out_of_range);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// RpcClient::invokeMethod()
+TEST_F(RpcClientTest, InvokeFutureWithoutPayload) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+
+	EXPECT_TRUE(invoke_future.valid());
+	validateLastRequest(1);
+	EXPECT_TRUE(transport_->message_.payload().empty());
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		EXPECT_TRUE(maybe_response);
+		EXPECT_TRUE(response == maybe_response.value());
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadAndFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_SOMEIP);
+
+	EXPECT_THROW(
+	    auto invoke_future = client.invokeMethod(),
+	    uprotocol::datamodel::builder::UMessageBuilder::UnexpectedFormat);
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_FALSE(transport_->listener_);
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadTimeout) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	decltype(client.invokeMethod()) invoke_future;
+	auto when_requested = std::chrono::steady_clock::now();
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(150ms);
+	auto when_expired = std::chrono::steady_clock::now();
+
+	EXPECT_GE((when_expired - when_requested), 10ms);
+	EXPECT_LE((when_expired - when_requested), 2 * 10ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadListenFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->registerListener_status_.set_code(
+	    uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadSendFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->send_status_.set_code(
+	    uprotocol::v1::UCode::FAILED_PRECONDITION);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadClientDestroyed) {
+	std::future<uprotocol::communication::RpcClient::MessageOrStatus>
+	    invoke_future;
+
+	{
+		auto client = uprotocol::communication::RpcClient(
+		    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+
+		EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+	}
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::CANCELLED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithoutPayloadCommstatus) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod());
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	response_builder.withCommStatus(uprotocol::v1::UCode::PERMISSION_DENIED);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UCode>(
+		    maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// RpcClient::invokeMethod(Payload)
+TEST_F(RpcClientTest, InvokeFutureWithPayload) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	auto payload = fakePayload();
+	auto payload_content = payload.buildCopy();
+
+	decltype(client.invokeMethod(std::move(payload))) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(std::move(payload)));
+
+	EXPECT_TRUE(invoke_future.valid());
+	validateLastRequest(1);
+	using PayloadField = uprotocol::datamodel::builder::Payload::PayloadType;
+	EXPECT_EQ(transport_->message_.payload(),
+	          std::get<PayloadField::Data>(payload_content));
+	EXPECT_EQ(transport_->message_.attributes().payload_format(),
+	          std::get<PayloadField::Format>(payload_content));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		EXPECT_TRUE(maybe_response);
+		EXPECT_TRUE(response == maybe_response.value());
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadAndFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_TEXT);
+
+	auto payload = fakePayload();
+	auto payload_content = payload.buildCopy();
+
+	decltype(client.invokeMethod(std::move(payload))) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(std::move(payload)));
+
+	EXPECT_TRUE(invoke_future.valid());
+	validateLastRequest(1);
+	using PayloadField = uprotocol::datamodel::builder::Payload::PayloadType;
+	EXPECT_EQ(transport_->message_.payload(),
+	          std::get<PayloadField::Data>(payload_content));
+	EXPECT_EQ(transport_->message_.attributes().payload_format(),
+	          std::get<PayloadField::Format>(payload_content));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		EXPECT_TRUE(maybe_response);
+		EXPECT_TRUE(response == maybe_response.value());
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadAndWrongFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_JSON);
+
+	EXPECT_THROW(
+	    auto invoke_future = client.invokeMethod(fakePayload()),
+	    uprotocol::datamodel::builder::UMessageBuilder::UnexpectedFormat);
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_FALSE(transport_->listener_);
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadTimeout) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	decltype(client.invokeMethod()) invoke_future;
+	auto when_requested = std::chrono::steady_clock::now();
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(fakePayload()));
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(150ms);
+	auto when_expired = std::chrono::steady_clock::now();
+
+	EXPECT_GE((when_expired - when_requested), 10ms);
+	EXPECT_LE((when_expired - when_requested), 2 * 10ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadListenFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->registerListener_status_.set_code(
+	    uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(fakePayload()));
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadSendFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->send_status_.set_code(
+	    uprotocol::v1::UCode::FAILED_PRECONDITION);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(fakePayload()));
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadClientDestroyed) {
+	std::future<uprotocol::communication::RpcClient::MessageOrStatus>
+	    invoke_future;
+
+	{
+		auto client = uprotocol::communication::RpcClient(
+		    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+
+		EXPECT_NO_THROW(invoke_future = client.invokeMethod(fakePayload()));
+	}
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UStatus>(
+		    maybe_response, uprotocol::v1::UCode::CANCELLED);
+	}
+}
+
+TEST_F(RpcClientTest, InvokeFutureWithPayloadCommstatus) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	decltype(client.invokeMethod()) invoke_future;
+	EXPECT_NO_THROW(invoke_future = client.invokeMethod(fakePayload()));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	response_builder.withCommStatus(uprotocol::v1::UCode::PERMISSION_DENIED);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(invoke_future.valid());
+	auto is_ready = invoke_future.wait_for(0ms);
+
+	EXPECT_EQ(is_ready, std::future_status::ready);
+	if (is_ready == std::future_status::ready) {
+		auto maybe_response = invoke_future.get();
+		checkErrorResponse<uprotocol::v1::UCode>(
+		    maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// RpcClient::invokeMethod(Callback)
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayload) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	bool callback_called = false;
+	uprotocol::v1::UMessage received_response;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    [this, &callback_called, &received_response](auto maybe_response) {
+		    callback_called = true;
+		    EXPECT_TRUE(maybe_response);
+		    received_response = std::move(maybe_response).value();
+	    }));
+
+	validateLastRequest(1);
+	EXPECT_TRUE(transport_->message_.payload().empty());
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(callback_called);
+	EXPECT_TRUE(response == received_response);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadAndFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_SOMEIP);
+
+	EXPECT_THROW(
+	    client.invokeMethod([](auto) {}),
+	    uprotocol::datamodel::builder::UMessageBuilder::UnexpectedFormat);
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_FALSE(transport_->listener_);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadTimeout) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	bool callback_called = false;
+	std::condition_variable callback_event;
+	auto when_requested = std::chrono::steady_clock::now();
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    [this, &callback_called, &callback_event](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		    callback_event.notify_all();
+	    }));
+
+	std::mutex mtx;
+	std::unique_lock lock(mtx);
+	callback_called = callback_event.wait_for(
+	    lock, 150ms, [&callback_called]() { return callback_called; });
+	auto when_expired = std::chrono::steady_clock::now();
+
+	EXPECT_GE((when_expired - when_requested), 10ms);
+	EXPECT_LE((when_expired - when_requested), 2 * 10ms);
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadListenFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->registerListener_status_.set_code(
+	    uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(
+	    client.invokeMethod([this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+	    }));
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadSendFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->send_status_.set_code(
+	    uprotocol::v1::UCode::FAILED_PRECONDITION);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(
+	    client.invokeMethod([this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+	    }));
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadClientDestroyed) {
+	std::future<uprotocol::communication::RpcClient::MessageOrStatus>
+	    invoke_future;
+
+	bool callback_called = false;
+
+	{
+		auto client = uprotocol::communication::RpcClient(
+		    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+
+		EXPECT_NO_THROW(
+		    client.invokeMethod([this, &callback_called](auto maybe_response) {
+			    callback_called = true;
+			    checkErrorResponse<uprotocol::v1::UStatus>(
+			        maybe_response, uprotocol::v1::UCode::CANCELLED);
+		    }));
+	}
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadCommstatus) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(
+	    client.invokeMethod([this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UCode>(
+		        maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+	    }));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	response_builder.withCommStatus(uprotocol::v1::UCode::PERMISSION_DENIED);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(callback_called);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// RpcClient::invokeMethod(Payload, Callback)
+TEST_F(RpcClientTest, InvokeCallbackWithPayload) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	auto payload = fakePayload();
+	auto payload_content = payload.buildCopy();
+
+	bool callback_called = false;
+	uprotocol::v1::UMessage received_response;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    std::move(payload),
+	    [this, &callback_called, &received_response](auto maybe_response) {
+		    callback_called = true;
+		    EXPECT_TRUE(maybe_response);
+		    received_response = std::move(maybe_response).value();
+	    }));
+
+	validateLastRequest(1);
+	using PayloadField = uprotocol::datamodel::builder::Payload::PayloadType;
+	EXPECT_EQ(transport_->message_.payload(),
+	          std::get<PayloadField::Data>(payload_content));
+	EXPECT_EQ(transport_->message_.attributes().payload_format(),
+	          std::get<PayloadField::Format>(payload_content));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(callback_called);
+	EXPECT_TRUE(response == received_response);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadAndFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_TEXT);
+
+	auto payload = fakePayload();
+	auto payload_content = payload.buildCopy();
+
+	bool callback_called = false;
+	uprotocol::v1::UMessage received_response;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    std::move(payload),
+	    [this, &callback_called, &received_response](auto maybe_response) {
+		    callback_called = true;
+		    EXPECT_TRUE(maybe_response);
+		    received_response = std::move(maybe_response).value();
+	    }));
+
+	validateLastRequest(1);
+	using PayloadField = uprotocol::datamodel::builder::Payload::PayloadType;
+	EXPECT_EQ(transport_->message_.payload(),
+	          std::get<PayloadField::Data>(payload_content));
+	EXPECT_EQ(transport_->message_.attributes().payload_format(),
+	          std::get<PayloadField::Format>(payload_content));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(callback_called);
+	EXPECT_TRUE(response == received_response);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadAndWrongFormatSet) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_JSON);
+
+	EXPECT_THROW(
+	    client.invokeMethod(fakePayload(), [](auto) {}),
+	    uprotocol::datamodel::builder::UMessageBuilder::UnexpectedFormat);
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_FALSE(transport_->listener_);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadTimeout) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	bool callback_called = false;
+	std::condition_variable callback_event;
+
+	auto when_requested = std::chrono::steady_clock::now();
+	EXPECT_NO_THROW(client.invokeMethod(
+	    fakePayload(),
+	    [this, &callback_called, &callback_event](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		    callback_event.notify_all();
+	    }));
+
+	std::mutex mtx;
+	std::unique_lock lock(mtx);
+	callback_called = callback_event.wait_for(
+	    lock, 150ms, [&callback_called]() { return callback_called; });
+	auto when_expired = std::chrono::steady_clock::now();
+
+	EXPECT_GE((when_expired - when_requested), 10ms);
+	EXPECT_LE((when_expired - when_requested), 2 * 10ms);
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadListenFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->registerListener_status_.set_code(
+	    uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    fakePayload(), [this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+	    }));
+
+	EXPECT_EQ(transport_->send_count_, 0);
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadSendFail) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	transport_->send_status_.set_code(
+	    uprotocol::v1::UCode::FAILED_PRECONDITION);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    fakePayload(), [this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UStatus>(
+		        maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+	    }));
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadClientDestroyed) {
+	std::future<uprotocol::communication::RpcClient::MessageOrStatus>
+	    invoke_future;
+
+	bool callback_called = false;
+
+	{
+		auto client = uprotocol::communication::RpcClient(
+		    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+
+		EXPECT_NO_THROW(client.invokeMethod(
+		    fakePayload(), [this, &callback_called](auto maybe_response) {
+			    callback_called = true;
+			    checkErrorResponse<uprotocol::v1::UStatus>(
+			        maybe_response, uprotocol::v1::UCode::CANCELLED);
+		    }));
+	}
+
+	EXPECT_TRUE(callback_called);
+}
+
+TEST_F(RpcClientTest, InvokeCallbackWithPayloadCommstatus) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	bool callback_called = false;
+
+	EXPECT_NO_THROW(client.invokeMethod(
+	    fakePayload(), [this, &callback_called](auto maybe_response) {
+		    callback_called = true;
+		    checkErrorResponse<uprotocol::v1::UCode>(
+		        maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+	    }));
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+	auto response_builder = UMessageBuilder::response(transport_->message_);
+	response_builder.withCommStatus(uprotocol::v1::UCode::PERMISSION_DENIED);
+	auto response = response_builder.build();
+	EXPECT_NO_THROW(transport_->mockMessage(response));
+
+	EXPECT_TRUE(callback_called);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Usecases
+TEST_F(RpcClientTest, MultiplePendingInvocationsOnOneClient) {
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+	    250ms);
+
+	std::list<decltype(client.invokeMethod())> futures;
+	std::list<std::decay_t<decltype(transport_->listener_.value())>> callables;
+	std::list<uprotocol::v1::UMessage> requests;
+
+	futures.push_back(client.invokeMethod());
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	futures.push_back(client.invokeMethod(fakePayload()));
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	futures.push_back(client.invokeMethod());
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	futures.push_back(client.invokeMethod(fakePayload()));
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	std::vector<uprotocol::transport::UTransport::ListenHandle> handles;
+
+	int callback_count = 0;
+	auto callback = [&callback_count](auto) { ++callback_count; };
+
+	client.invokeMethod(callback);
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	client.invokeMethod(fakePayload(), callback);
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	client.invokeMethod(callback);
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	client.invokeMethod(fakePayload(), callback);
+	callables.push_back(transport_->listener_.value());
+	requests.push_back(transport_->message_);
+
+	auto readyFutures = [&futures]() {
+		size_t ready = 0;
+		for (auto& future : futures) {
+			auto is_ready = future.wait_for(0ms);
+			if (is_ready == std::future_status::ready) {
+				++ready;
+			}
+		}
+		return ready;
+	};
+
+	EXPECT_EQ(callback_count, 0);
+	EXPECT_EQ(readyFutures(), 0);
+
+	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
+
+	auto deliverMessage = [&callables](uprotocol::v1::UMessage&& message) {
+		for (auto& callable : callables) {
+			callable(std::move(message));
+		}
+	};
+
+	deliverMessage(UMessageBuilder::response(requests.front()).build());
+	deliverMessage(UMessageBuilder::response(requests.back()).build());
+
+	EXPECT_EQ(callback_count, 1);
+	EXPECT_EQ(readyFutures(), 1);
+	EXPECT_EQ(futures.front().wait_for(0ms), std::future_status::ready);
+
+	requests.pop_front();
+	requests.pop_back();
+
+	deliverMessage(UMessageBuilder::response(requests.front()).build());
+	deliverMessage(UMessageBuilder::response(requests.back()).build());
+	requests.pop_front();
+	requests.pop_back();
+	deliverMessage(UMessageBuilder::response(requests.front()).build());
+	deliverMessage(UMessageBuilder::response(requests.back()).build());
+
+	EXPECT_EQ(callback_count, 3);
+	EXPECT_EQ(readyFutures(), 3);
+
+	// Intentionally leaving a couple pending requests to discard
+}
+
+TEST_F(RpcClientTest, PendingRequestsExpireInOrder) {
+	constexpr size_t num_clients = 10;
+	std::vector<std::tuple<size_t, uprotocol::communication::RpcClient>>
+	    clients;
+
+	std::mutex expire_mtx;
+	std::vector<size_t> expire_order;
+	std::condition_variable expire_signal;
+
+	std::vector<size_t> expected_order;
+
+	constexpr auto per_client_ttl_increment = 5ms;
+	auto client_ttl = 200ms;
+
+	for (size_t client_id = 0; client_id < num_clients;
+	     ++client_id, client_ttl += per_client_ttl_increment) {
+		auto transport = std::make_shared<uprotocol::test::UTransportMock>(
+		    defaultSourceUri());
+
+		clients.emplace_back(std::make_tuple(
+		    client_id,
+		    uprotocol::communication::RpcClient(
+		        transport, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		        client_ttl)));
+
+		expected_order.push_back(client_id);
+	}
+
+	for (auto entry = clients.rbegin(); entry != clients.rend(); ++entry) {
+		auto client_id = std::get<0>(*entry);
+		auto& client = std::get<1>(*entry);
+
+		client.invokeMethod([client_id, &expire_mtx, &expire_order,
+		                     &expire_signal](auto maybe_response) {
+			if (!maybe_response) {
+				auto some_status = maybe_response.error();
+				if (std::get<uprotocol::v1::UStatus>(some_status).code() !=
+				    uprotocol::v1::UCode::DEADLINE_EXCEEDED) {
+					return;
+				}
+				std::lock_guard lock(expire_mtx);
+				expire_order.push_back(client_id);
+				expire_signal.notify_one();
+			}
+		});
+	}
+
+	std::unique_lock lock(expire_mtx);
+	expire_signal.wait_for(lock, 2s, [&expire_order]() {
+		return expire_order.size() == num_clients;
+	});
+	EXPECT_EQ(expire_order.size(), num_clients);
+	EXPECT_TRUE(std::is_sorted(expire_order.begin(), expire_order.end()));
+	EXPECT_EQ(expire_order, expected_order);
+}
+
+TEST_F(RpcClientTest, MultipleClientInstances) {
+	constexpr size_t num_clients = 20;
+
+	using UTransportMock = uprotocol::test::UTransportMock;
+	std::array<std::shared_ptr<UTransportMock>, num_clients> transports;
+
+	uint8_t last_authority_octet = 0;
+	for (auto& transport : transports) {
+		std::ostringstream authority;
+		authority << "127.34.0." << last_authority_octet++;
+		auto uri = defaultSourceUri();
+		uri.set_authority_name(authority.str());
+		transport = std::make_shared<UTransportMock>(uri);
+	}
+
+	std::array<std::chrono::milliseconds, num_clients> timeouts;
+	constexpr std::chrono::milliseconds timeout_step = 7ms;
+	constexpr std::chrono::milliseconds timeout_min = 200ms;
+	constexpr std::chrono::milliseconds timeout_max = timeout_min + 40ms;
+	std::chrono::milliseconds next_timeout = timeout_min;
+	for (auto& timeout : timeouts) {
+		timeout = next_timeout;
+		next_timeout = ((next_timeout - timeout_min + timeout_step) %
+		                (timeout_max - timeout_min)) +
+		               timeout_min;
+	}
+
+	std::vector<uprotocol::communication::RpcClient> clients;
+
+	auto loop_init =
+	    std::make_tuple(num_clients, transports.begin(), timeouts.begin());
+
+	for (auto [remaining, transport, timeout] = std::move(loop_init);
+	     remaining > 0; --remaining, ++transport, ++timeout) {
+		auto method_uri = (*transport)->getDefaultSource();
+		method_uri.set_resource_id(methodUri().resource_id());
+		uprotocol::communication::RpcClient client(
+		    *transport, std::move(method_uri),
+		    uprotocol::v1::UPriority::UPRIORITY_CS4, *timeout);
+		clients.push_back(std::move(client));
+	}
+
+	constexpr size_t requests_per_client = 8;
+	constexpr size_t num_invocations = num_clients * requests_per_client;
+	using PendingEntry = std::tuple<std::chrono::steady_clock::time_point,
+	                                decltype(clients[0].invokeMethod())>;
+	std::vector<PendingEntry> pending;
+	std::array<size_t, num_clients> client_invoke_count{0};
+
+	for (size_t remaining = num_invocations; remaining > 0; --remaining) {
+		const size_t client_index = remaining % num_clients;
+		++client_invoke_count[client_index];
+		pending.push_back(
+		    {std::chrono::steady_clock::now() + timeouts[client_index],
+		     clients[client_index].invokeMethod()});
+	}
+
+	// Reply to some
+	for (auto& transport : transports) {
+		using namespace uprotocol::datamodel::builder;
+		auto reply = UMessageBuilder::response(transport->message_).build();
+		transport->mockMessage(std::move(reply));
+	}
+	size_t num_ready = 0;
+	for (auto& request : pending) {
+		auto& future = std::get<1>(request);
+		const bool is_ready = future.wait_for(0ms) == std::future_status::ready;
+		if (is_ready) {
+			++num_ready;
+			auto maybe_response = future.get();
+			EXPECT_TRUE(maybe_response);
+		}
+	}
+	// The transport mock only keeps the last message, so the maximum we
+	// could have sent is the number of transport mocks we have
+	EXPECT_EQ(num_ready, transports.size());
+
+	// Drop some by discarding the client
+	constexpr size_t num_discard = 2;
+	for (auto remaining = num_discard; remaining > 0; --remaining) {
+		clients.pop_back();
+	}
+	size_t num_cancelled = 0;
+	for (auto& request : pending) {
+		auto& future = std::get<1>(request);
+		// Ignoring the futures we have already used
+		if (future.valid() &&
+		    (future.wait_for(0ms) == std::future_status::ready)) {
+			auto maybe_response = future.get();
+			checkErrorResponse<uprotocol::v1::UStatus>(
+			    maybe_response, uprotocol::v1::UCode::CANCELLED);
+			++num_cancelled;
+		}
+	}
+	// Note: removing two for the two futures already used earlier in the test
+	EXPECT_EQ(num_cancelled, num_discard * (requests_per_client - 1));
+
+	// Prune all completed requests
+	auto before_clean = pending.size();
+	pending.erase(remove_if(pending.begin(), pending.end(),
+	                        [](const auto& request) {
+		                        return !std::get<1>(request).valid();
+	                        }),
+	              pending.end());
+	EXPECT_EQ(pending.size(), before_clean - num_cancelled - num_ready);
+
+	// Wait for some to time out
+	decltype(pending.begin()) pending_middle =
+	    pending.begin() + (pending.size() / 2);
+	std::nth_element(
+	    pending.begin(), pending_middle, pending.end(),
+	    [](const auto& a, const auto& b) {
+		    if (!std::get<1>(a).valid() || !std::get<1>(b).valid()) {
+			    return false;
+		    }
+		    return std::get<0>(a) < std::get<0>(b);
+	    });
+
+	auto& median_expire_future = std::get<1>(*pending_middle);
+	median_expire_future.wait_until(std::get<0>(*pending_middle) +
+	                                timeout_step);
+
+	size_t expected_expired = 0;
+	size_t ready_futures = 0;
+	size_t expired_futures = 0;
+	for (auto& request : pending) {
+		auto& when_expire = std::get<0>(request);
+		auto& future = std::get<1>(request);
+		if (future.valid() &&
+		    (when_expire <= std::chrono::steady_clock::now())) {
+			++expected_expired;
+
+			if (future.wait_for(2 * timeout_step) ==
+			    std::future_status::ready) {
+				++ready_futures;
+				auto maybe_message = future.get();
+				if (!maybe_message &&
+				    (std::get<uprotocol::v1::UStatus>(maybe_message.error())
+				         .code() == uprotocol::v1::UCode::DEADLINE_EXCEEDED)) {
+					++expired_futures;
+					checkErrorResponse<uprotocol::v1::UStatus>(
+					    maybe_message, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+				}
+			}
+		}
+	}
+	EXPECT_LE(expected_expired, pending.size());
+	EXPECT_GE(expected_expired, 1);
+	EXPECT_GE(ready_futures, expected_expired);
+	EXPECT_EQ(expired_futures, expected_expired);
+
+	// Discard the rest
+}
+
+TEST_F(RpcClientTest, ParallelAccessSingleClient) {
+	std::array<std::thread, 10> workers;
+
+	auto client = uprotocol::communication::RpcClient(
+	    transport_, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4, 10ms);
+
+	constexpr size_t num_requests_per_worker = 10;
+	std::atomic<size_t> call_count = 0;
+
+	for (auto& worker : workers) {
+		worker = std::thread([&call_count, &client]() {
+			for (auto remaining = num_requests_per_worker; remaining > 0;
+			     --remaining) {
+				client.invokeMethod([&call_count](auto) { ++call_count; });
+			}
+		});
+	}
+
+	for (auto& worker : workers) {
+		worker.join();
+	}
+
+	for (int remaining_attempts = 10; remaining_attempts > 0;
+	     --remaining_attempts) {
+		std::this_thread::sleep_for(20ms);
+		if (call_count == num_requests_per_worker * workers.size()) {
+			break;
+		}
+	}
+	EXPECT_EQ(call_count, num_requests_per_worker * workers.size());
+}
+
+TEST_F(RpcClientTest, ParallelAccessMultipleClients) {
+	std::vector<std::thread> workers;
+
+	constexpr size_t num_requests_per_worker = 1500;
+
+	auto get_client = []() {
+		auto transport = std::make_shared<uprotocol::test::UTransportMock>(
+		    defaultSourceUri());
+		return uprotocol::communication::RpcClient(
+		    transport, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+	};
+
+	// Repeatedly creates a client, makes a request, then discards the client
+	std::atomic<int> discard_calls = 0;
+
+	workers.emplace_back([&discard_calls, &get_client]() {
+		for (auto remaining_requests = num_requests_per_worker;
+		     remaining_requests > 0; --remaining_requests) {
+			auto client = get_client();
+			client.invokeMethod([&discard_calls](auto) { ++discard_calls; });
+		}
+	});
+
+	// Creates a client, then repeatedly issues requests, discarding its future
+	// without waiting for the request to complete
+	// NOTE: This one should not increase the call count
+	std::atomic<int> abandon_calls = 0;
+
+	workers.emplace_back([&abandon_calls, &get_client]() {
+		auto client = get_client();
+		for (auto remaining_requests = num_requests_per_worker;
+		     remaining_requests > 0; --remaining_requests) {
+			auto future = client.invokeMethod();
+			if (future.valid() &&
+			    (future.wait_for(0ms) == std::future_status::ready)) {
+				++abandon_calls;
+			}
+		}
+	});
+
+	// Creates a client then repeatedly issues requests, holding the futures
+	// and totalling up the number fulfilled (by expiration)
+	std::atomic<int> expire_calls = 0;
+	std::atomic<int> broken_promises = 0;
+
+	workers.emplace_back([&expire_calls, &broken_promises, &get_client]() {
+		auto client = get_client();
+		std::vector<decltype(client.invokeMethod())> futures;
+		for (auto remaining_requests = num_requests_per_worker;
+		     remaining_requests > 0; --remaining_requests) {
+			futures.emplace_back(client.invokeMethod());
+		}
+		for (auto& future : futures) {
+			auto is_ready = future.wait_for(1s);
+			if (is_ready == std::future_status::ready) {
+				try {
+					auto maybe_response = future.get();
+					++expire_calls;
+				} catch (const std::future_error& e) {
+					if (e.code() == std::future_errc::broken_promise) {
+						++broken_promises;
+					} else {
+						// Re-throwing to break the test is something other
+						// than a broken promise occurred.
+						throw e;
+					}
+				}
+			}
+		}
+	});
+
+	// Creates a client then repeatedly issues requests, responding to its own
+	// requests
+	std::atomic<int> self_calls = 0;
+
+	auto self_responder = [&self_calls, &get_client]() {
+		auto transport = std::make_shared<uprotocol::test::UTransportMock>(
+		    defaultSourceUri());
+		auto client = uprotocol::communication::RpcClient(
+		    transport, methodUri(), uprotocol::v1::UPriority::UPRIORITY_CS4,
+		    10ms);
+		for (auto remaining_requests = num_requests_per_worker;
+		     remaining_requests > 0; --remaining_requests) {
+			client.invokeMethod([&self_calls](auto) { ++self_calls; });
+			// Attempting this without a request having ever been sent results
+			// in an InvalidUUri exception thrown from a thread. gtest can't
+			// guard for that, so we avoid generating the exception.
+			if (transport->send_count_ > 0) {
+				using namespace uprotocol::datamodel::builder;
+				auto response =
+				    UMessageBuilder::response(transport->message_).build();
+				transport->mockMessage(response);
+			}
+		}
+	};
+	constexpr size_t num_self_responders = 3;
+	for (auto remaining = num_self_responders; remaining > 0; --remaining) {
+		workers.emplace_back(self_responder);
+	}
+
+	// Wait for all workers to complete to get the final tally
+	for (auto& worker : workers) {
+		worker.join();
+	}
+
+	EXPECT_EQ(discard_calls, num_requests_per_worker);
+	EXPECT_EQ(abandon_calls, 0);
+	EXPECT_EQ(broken_promises, 0);
+	EXPECT_EQ(expire_calls, num_requests_per_worker);
+	EXPECT_EQ(self_calls, num_requests_per_worker * num_self_responders);
+}
 
 }  // namespace

--- a/test/coverage/communication/RpcClientTest.cpp
+++ b/test/coverage/communication/RpcClientTest.cpp
@@ -40,12 +40,6 @@ bool operator==(const uprotocol::v1::UMessage& lhs,
 }
 
 bool operator==(const uprotocol::v1::UStatus& lhs,
-                const uprotocol::v1::UStatus& rhs) {
-	using namespace google::protobuf::util;
-	return MessageDifferencer::Equals(lhs, rhs);
-}
-
-bool operator==(const uprotocol::v1::UStatus& lhs,
                 const uprotocol::v1::UCode& rhs) {
 	return lhs.code() == rhs;
 }

--- a/test/coverage/communication/RpcClientTest.cpp
+++ b/test/coverage/communication/RpcClientTest.cpp
@@ -113,18 +113,14 @@ protected:
 	std::shared_ptr<uprotocol::test::UTransportMock> transport_;
 };
 
-template <typename StatusT, typename ExpectedT>
+template <typename ExpectedT>
 void checkErrorResponse(
     const uprotocol::communication::RpcClient::MessageOrStatus& maybe_response,
     ExpectedT expected_status) {
 	EXPECT_FALSE(maybe_response);
 	if (!maybe_response) {
-		auto& some_status = maybe_response.error();
-		EXPECT_TRUE(std::holds_alternative<StatusT>(some_status));
-		if (std::holds_alternative<StatusT>(some_status)) {
-			auto& status = std::get<StatusT>(some_status);
-			EXPECT_TRUE(status == expected_status);
-		}
+		auto& status = maybe_response.error();
+		EXPECT_TRUE(status == expected_status);
 	}
 }
 
@@ -252,8 +248,8 @@ TEST_F(RpcClientTest, InvokeFutureWithoutPayloadTimeout) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::DEADLINE_EXCEEDED);
 	}
 }
 
@@ -274,8 +270,8 @@ TEST_F(RpcClientTest, InvokeFutureWithoutPayloadListenFail) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
 	}
 }
 
@@ -295,8 +291,8 @@ TEST_F(RpcClientTest, InvokeFutureWithoutPayloadSendFail) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::FAILED_PRECONDITION);
 	}
 }
 
@@ -317,8 +313,8 @@ TEST_F(RpcClientTest, InvokeFutureWithoutPayloadClientDestroyed) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		EXPECT_NO_THROW(auto maybe_response = invoke_future.get();
-		                checkErrorResponse<uprotocol::v1::UStatus>(
-		                    maybe_response, uprotocol::v1::UCode::CANCELLED););
+		                checkErrorResponse(maybe_response,
+		                                   uprotocol::v1::UCode::CANCELLED););
 	}
 }
 
@@ -341,8 +337,8 @@ TEST_F(RpcClientTest, InvokeFutureWithoutPayloadCommstatus) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UCode>(
-		    maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::PERMISSION_DENIED);
 	}
 }
 
@@ -446,8 +442,8 @@ TEST_F(RpcClientTest, InvokeFutureWithPayloadTimeout) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::DEADLINE_EXCEEDED);
 	}
 }
 
@@ -468,8 +464,8 @@ TEST_F(RpcClientTest, InvokeFutureWithPayloadListenFail) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
 	}
 }
 
@@ -489,8 +485,8 @@ TEST_F(RpcClientTest, InvokeFutureWithPayloadSendFail) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::FAILED_PRECONDITION);
 	}
 }
 
@@ -511,8 +507,7 @@ TEST_F(RpcClientTest, InvokeFutureWithPayloadClientDestroyed) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::CANCELLED);
+		checkErrorResponse(maybe_response, uprotocol::v1::UCode::CANCELLED);
 	}
 }
 
@@ -535,8 +530,8 @@ TEST_F(RpcClientTest, InvokeFutureWithPayloadCommstatus) {
 	EXPECT_EQ(is_ready, std::future_status::ready);
 	if (is_ready == std::future_status::ready) {
 		auto maybe_response = invoke_future.get();
-		checkErrorResponse<uprotocol::v1::UCode>(
-		    maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::PERMISSION_DENIED);
 	}
 }
 
@@ -597,8 +592,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadTimeout) {
 	    handle = client.invokeMethod(
 	        [this, &callback_called, &callback_event](auto maybe_response) {
 		        callback_called = true;
-		        checkErrorResponse<uprotocol::v1::UStatus>(
-		            maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		        checkErrorResponse(maybe_response,
+		                           uprotocol::v1::UCode::DEADLINE_EXCEEDED);
 		        callback_event.notify_all();
 	        }));
 
@@ -627,8 +622,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadListenFail) {
 	EXPECT_NO_THROW(handle = client.invokeMethod([this, &callback_called](
 	                                                 auto maybe_response) {
 		callback_called = true;
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
 	}));
 
 	EXPECT_EQ(transport_->send_count_, 0);
@@ -648,8 +643,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadSendFail) {
 	EXPECT_NO_THROW(handle = client.invokeMethod([this, &callback_called](
 	                                                 auto maybe_response) {
 		callback_called = true;
-		checkErrorResponse<uprotocol::v1::UStatus>(
-		    maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::FAILED_PRECONDITION);
 	}));
 
 	EXPECT_TRUE(callback_called);
@@ -669,8 +664,7 @@ TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadClientDestroyed) {
 		EXPECT_NO_THROW(handle = client.invokeMethod([this, &callback_called](
 		                                                 auto maybe_response) {
 			callback_called = true;
-			checkErrorResponse<uprotocol::v1::UStatus>(
-			    maybe_response, uprotocol::v1::UCode::CANCELLED);
+			checkErrorResponse(maybe_response, uprotocol::v1::UCode::CANCELLED);
 		}));
 	}
 
@@ -687,8 +681,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithoutPayloadCommstatus) {
 	EXPECT_NO_THROW(handle = client.invokeMethod([this, &callback_called](
 	                                                 auto maybe_response) {
 		callback_called = true;
-		checkErrorResponse<uprotocol::v1::UCode>(
-		    maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+		checkErrorResponse(maybe_response,
+		                   uprotocol::v1::UCode::PERMISSION_DENIED);
 	}));
 
 	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
@@ -803,8 +797,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithPayloadTimeout) {
 	        fakePayload(),
 	        [this, &callback_called, &callback_event](auto maybe_response) {
 		        callback_called = true;
-		        checkErrorResponse<uprotocol::v1::UStatus>(
-		            maybe_response, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+		        checkErrorResponse(maybe_response,
+		                           uprotocol::v1::UCode::DEADLINE_EXCEEDED);
 		        callback_event.notify_all();
 	        }));
 
@@ -834,8 +828,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithPayloadListenFail) {
 	    handle = client.invokeMethod(
 	        fakePayload(), [this, &callback_called](auto maybe_response) {
 		        callback_called = true;
-		        checkErrorResponse<uprotocol::v1::UStatus>(
-		            maybe_response, uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
+		        checkErrorResponse(maybe_response,
+		                           uprotocol::v1::UCode::RESOURCE_EXHAUSTED);
 	        }));
 
 	EXPECT_EQ(transport_->send_count_, 0);
@@ -856,8 +850,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithPayloadSendFail) {
 	    handle = client.invokeMethod(
 	        fakePayload(), [this, &callback_called](auto maybe_response) {
 		        callback_called = true;
-		        checkErrorResponse<uprotocol::v1::UStatus>(
-		            maybe_response, uprotocol::v1::UCode::FAILED_PRECONDITION);
+		        checkErrorResponse(maybe_response,
+		                           uprotocol::v1::UCode::FAILED_PRECONDITION);
 	        }));
 
 	EXPECT_TRUE(callback_called);
@@ -878,8 +872,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithPayloadClientDestroyed) {
 		    handle = client.invokeMethod(
 		        fakePayload(), [this, &callback_called](auto maybe_response) {
 			        callback_called = true;
-			        checkErrorResponse<uprotocol::v1::UStatus>(
-			            maybe_response, uprotocol::v1::UCode::CANCELLED);
+			        checkErrorResponse(maybe_response,
+			                           uprotocol::v1::UCode::CANCELLED);
 		        }));
 	}
 
@@ -897,8 +891,8 @@ TEST_F(RpcClientTest, InvokeCallbackWithPayloadCommstatus) {
 	    handle = client.invokeMethod(
 	        fakePayload(), [this, &callback_called](auto maybe_response) {
 		        callback_called = true;
-		        checkErrorResponse<uprotocol::v1::UCode>(
-		            maybe_response, uprotocol::v1::UCode::PERMISSION_DENIED);
+		        checkErrorResponse(maybe_response,
+		                           uprotocol::v1::UCode::PERMISSION_DENIED);
 	        }));
 
 	using UMessageBuilder = uprotocol::datamodel::builder::UMessageBuilder;
@@ -1042,7 +1036,7 @@ TEST_F(RpcClientTest, PendingRequestsExpireInOrder) {
 		                         &expire_signal](auto maybe_response) {
 			    if (!maybe_response) {
 				    auto some_status = maybe_response.error();
-				    if (std::get<uprotocol::v1::UStatus>(some_status).code() !=
+				    if (some_status.code() !=
 				        uprotocol::v1::UCode::DEADLINE_EXCEEDED) {
 					    return;
 				    }
@@ -1152,8 +1146,7 @@ TEST_F(RpcClientTest, MultipleClientInstances) {
 		if (future.valid() &&
 		    (future.wait_for(0ms) == std::future_status::ready)) {
 			auto maybe_response = future.get();
-			checkErrorResponse<uprotocol::v1::UStatus>(
-			    maybe_response, uprotocol::v1::UCode::CANCELLED);
+			checkErrorResponse(maybe_response, uprotocol::v1::UCode::CANCELLED);
 			++num_cancelled;
 		}
 	}
@@ -1200,11 +1193,11 @@ TEST_F(RpcClientTest, MultipleClientInstances) {
 				++ready_futures;
 				auto maybe_message = future.get();
 				if (!maybe_message &&
-				    (std::get<uprotocol::v1::UStatus>(maybe_message.error())
-				         .code() == uprotocol::v1::UCode::DEADLINE_EXCEEDED)) {
+				    (maybe_message.error().code() ==
+				     uprotocol::v1::UCode::DEADLINE_EXCEEDED)) {
 					++expired_futures;
-					checkErrorResponse<uprotocol::v1::UStatus>(
-					    maybe_message, uprotocol::v1::UCode::DEADLINE_EXCEEDED);
+					checkErrorResponse(maybe_message,
+					                   uprotocol::v1::UCode::DEADLINE_EXCEEDED);
 				}
 			}
 		}


### PR DESCRIPTION
`RpcClient` implements the client side of the layer 2 RPC model. It must be able to:

1. Send well-formed request messages to a listening RPC server
2. Map responses back to the original caller using the request's message UUID
3. Provide response messages to the caller
4. Expire pending requests that have been waiting longer than the request TTL

----

When invoking an RPC method, the sequence of events is as follows:

- A request message is generated
- A listener wrapper for the caller's callback (or promise) is generated. This listener will check the request ID in the response against the ID from the original request, only passing the response onward when they match
- An expiration wrapper for the caller's callback is generated
- The listener wrapper is registered with the transport for the entity's RPC response URI. If an error is reported, the expiration wrapper is called and the error status is passed to the caller
- If the listener is registered successfully, the request is sent. If an error is reported, the expiration wrapper is called and the error status is passed to the caller
- If the request is sent successfully, then the expiration wrapper is queued with the thread that monitors for timeout events

A single shared thread (`ExpireWorker`) monitors a priority queue of pending requests. The queue is sorted such that the earliest expiration is always at the top of the queue. When entries are added to the queue, a condition variable wakes the worker. The worker sleeps until the next expiration time. If the expiring request has not already been fulfilled, then the worker will call the expiration wrapper to inform the waiting caller that the RPC request has timed out.