### PR TITLE
Ignore test results when generating coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           cd up-cpp/build
           chmod +x bin/*
-          ctest
+          ctest || true
 
       - name: Run Coverage report
         shell: bash


### PR DESCRIPTION
Coverage reports should always be generated, even if the tests are failing. A separate job in the CI process checks for test results.

Closes #204 