### PR TITLE
Enhancing the clang-format linter script

### DIFF
--- a/lint/clang-format.sh
+++ b/lint/clang-format.sh
@@ -2,14 +2,27 @@
 
 PROJECT_ROOT="$(realpath "$(dirname "$0")/../")"
 
-echo "Running clang-format on all files in '$PROJECT_ROOT'"
+if [ -n "$(which clang-format-12)" ]; then
+    # NOTE: Using clang-format-12 in CI system, too
+    FORMATTER=clang-format-12
+elif [ -n "$(which clang-format)" ]; then
+    echo "Did not find clang-format-12. Trying clang-format. Results may not"
+    echo "match formatting in GitHub CI process."
+    FORMATTER=clang-format
+else
+    echo "Could not find clang-format. Please make sure it is installed" 1>&2
+    exit 2
+fi
+
+echo "Running $FORMATTER on all files in '$PROJECT_ROOT'"
 shopt -s globstar
 
-pushd -n "$PROJECT_ROOT"
+pushd "$PROJECT_ROOT" > /dev/null
 for f in **/*.h **/*.cpp; do
-	echo
-	echo "Checking file '$f'"
-	# NOTE: Using clang-format-12 in CI system, too
-	clang-format-12 -i "$f"
+	if [[ ! ("$f" =~ "build/") ]]; then
+		echo
+		echo "Checking file '$f'"
+		$FORMATTER -i "$f"
+	fi
 done
-popd -n
+popd > /dev/null


### PR DESCRIPTION
Three main fixes / improvements:

* Now excludes the build folder to avoid spending a lot of time formatting the cmake compiler detection .cpp file.
* Checks if clang-format-12 is available, and if not falls back to clang-format
* Can be run from anywhere within the repo (pushd call fixed)