### PR TITLE
Removing spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ cmake_minimum_required(VERSION 3.10.0)
 project(up-cpp VERSION 1.0.0  LANGUAGES CXX DESCRIPTION "C++ API for uProtocol")
 
 find_package(protobuf REQUIRED)
-find_package(spdlog REQUIRED)
 find_package(up-core-api REQUIRED)
 
 message("* Adding build types...")
@@ -36,9 +35,6 @@ if(CMAKE_BUILD_TYPE STREQUAL Coverage)
 endif()
 message("* Current Compiler Flags: ${CMAKE_CXX_FLAGS}")
 
-# TODO NEEDED?
-#add_definitions(-DSPDLOG_FMT_EXTERNAL)
-
 # This is the root CMakeLists.txt file; We can set project wide settings here
 # TODO: Is this needed?
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
@@ -60,8 +56,7 @@ target_include_directories(${PROJECT_NAME}
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 	${up-core-api_INCLUDE_DIR}
-	${protobuf_INCLUDE_DIR}
-	${spdlog_INCLUDE_DIR})
+	${protobuf_INCLUDE_DIR})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -79,7 +74,6 @@ target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 	up-core-api::up-core-api
 	protobuf::libprotobuf
-	spdlog::spdlog
 	gcov)
 
 enable_testing()

--- a/NOTICE.adoc
+++ b/NOTICE.adoc
@@ -33,5 +33,4 @@ The following are libraries used by this project:
 * https://github.com/openssl/openssl
 * https://github.com/topics/libuuid
 * https://github.com/Tencent/rapidjson
-* https://github.com/gabime/spdlog
 * https://github.com/cgreen-devs/cgreen

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,5 @@
 [requires]
 up-core-api/1.6.0
-spdlog/1.13.0
 protobuf/3.21.12
 
 [test_requires]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,6 @@ function(add_coverage_test Name)
         PUBLIC
         up-core-api::up-core-api
         up-cpp::up-cpp
-        spdlog::spdlog
         protobuf::protobuf
         PRIVATE
         GTest::gtest_main


### PR DESCRIPTION
Nothing in the alpha.2 release code is using spdlog, so there is no need to include it as a depenency in the 1.0.0 release.

closes #226 