### PR TITLE
Enabling CI workflows for release branches 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main", "v1.0_up-v1.6.0" ]
   pull_request:
     branches: ["**"]
   

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v1.0_up-v1.6.0" ]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Test and Coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main", "v1.0_up-v1.6.0" ]
   pull_request:
     branches: ["**"]
   


### PR DESCRIPTION
They should be treated in the same way main is with new commits being validated automatically.