### PR TITLE
Add clang-tidy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main", "v1.0_up-v1.6.0" ]
   pull_request:
     branches: ["**"]
+
+permissions:
+  contents: read
   
 jobs:
   build:
@@ -379,6 +382,9 @@ jobs:
     name: Lint C++ sources
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Get build commands
@@ -410,7 +416,14 @@ jobs:
         with:
           path: up-cpp
 
+      - name: Get build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: up-cpp/build/Release
+
       - name: Run linters on source
+        continue-on-error: true
         id: source-linter
         uses: cpp-linter/cpp-linter-action@v2
         env:
@@ -420,9 +433,10 @@ jobs:
           ignore: 'test'
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
-          database: compile_commands.json
+          database: build/Release/compile_commands.json
 
       - name: Run linters on tests
+        continue-on-error: true
         id: test-linter
         uses: cpp-linter/cpp-linter-action@v2
         env:
@@ -432,7 +446,7 @@ jobs:
           ignore: 'src|include'
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
-          database: compile_commands.json
+          database: build/Release/compile_commands.json
 
       - name: Report lint failure
         if: steps.source-linter.outputs.checks-failed > 0 || steps.test-linter.outputs.checks-failed > 0


### PR DESCRIPTION
This PR adds clang-tidy and clang-format using cpplinter in github action. 