### PR TITLE
Shared_ptr<UTransport> nullptr check

### DIFF
--- a/src/communication/NotificationSource.cpp
+++ b/src/communication/NotificationSource.cpp
@@ -23,6 +23,10 @@ NotificationSource::NotificationSource(
       notify_builder_(
           UMessageBuilder::notification(std::move(source), std::move(sink))
               .withPriority(priority.value_or(v1::UPriority::UPRIORITY_CS1))) {
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	if (payload_format.has_value()) {
 		notify_builder_.withPayloadFormat(payload_format.value());
 	}
@@ -35,11 +39,16 @@ NotificationSource::NotificationSource(
 v1::UStatus NotificationSource::notify(
     datamodel::builder::Payload&& payload) const {
 	auto message = notify_builder_.build(std::move(payload));
+
 	return transport_->send(std::move(message));
 }
 
 v1::UStatus NotificationSource::notify() const {
 	auto message = notify_builder_.build();
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	return transport_->send(std::move(message));
 }
 

--- a/src/communication/Publisher.cpp
+++ b/src/communication/Publisher.cpp
@@ -25,6 +25,10 @@ Publisher::Publisher(std::shared_ptr<transport::UTransport> transport,
 	publish_builder_.withPayloadFormat(format).withPriority(
 	    priority.value_or(v1::UPriority::UPRIORITY_CS1));
 
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	if (ttl.has_value()) {
 		publish_builder_.withTtl(ttl.value());
 	}
@@ -32,6 +36,10 @@ Publisher::Publisher(std::shared_ptr<transport::UTransport> transport,
 
 v1::UStatus Publisher::publish(datamodel::builder::Payload&& payload) const {
 	auto message = publish_builder_.build(std::move(payload));
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	return transport_->send(std::move(message));
 }
 

--- a/src/communication/RpcServer.cpp
+++ b/src/communication/RpcServer.cpp
@@ -20,7 +20,11 @@ RpcServer::RpcServer(std::shared_ptr<transport::UTransport> transport,
                      std::optional<std::chrono::milliseconds> ttl)
     : transport_(std::move(transport)),
       ttl_(ttl),
-      expected_payload_format_(std::move(format)) {}
+      expected_payload_format_(std::move(format)) {
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+}
 
 RpcServer::ServerOrStatus RpcServer::create(
     std::shared_ptr<transport::UTransport> transport,
@@ -29,6 +33,11 @@ RpcServer::ServerOrStatus RpcServer::create(
     std::optional<std::chrono::milliseconds> ttl) {
 	// Validate the method name using a URI validator.
 	auto [valid, reason] = Validator::uri::isValidRpcMethod(method_name);
+
+	if (!transport) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	if (!valid) {
 		// If the method name is invalid, return an error status.
 		v1::UStatus status;
@@ -67,6 +76,11 @@ RpcServer::ServerOrStatus RpcServer::create(
 
 v1::UStatus RpcServer::connect(const v1::UUri& method, RpcCallback&& callback) {
 	callback_ = std::move(callback);
+
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
+
 	auto result = transport_->registerListener(
 	    // listener=
 	    [this](const v1::UMessage& request) {

--- a/src/communication/Subscriber.cpp
+++ b/src/communication/Subscriber.cpp
@@ -47,6 +47,9 @@ Subscriber::Subscriber(std::shared_ptr<transport::UTransport> transport,
                        ListenHandle&& subscription)
     : transport_(transport), subscription_(std::move(subscription)) {
 	// Constructor body. Any additional setup can go here.
+	if (!transport_) {
+		throw transport::NullTransport("transport cannot be null");
+	}
 }
 
 }  // namespace uprotocol::communication

--- a/test/coverage/communication/NotificationSourceTest.cpp
+++ b/test/coverage/communication/NotificationSourceTest.cpp
@@ -185,4 +185,14 @@ TEST_F(TestNotificationSource, NotifyWithoutPayloadFailure) {
 	EXPECT_EQ(status.code(), retval.code());
 }
 
+// Test with Null transport
+TEST_F(TestNotificationSource, NullTransport) {
+	auto transport = nullptr;
+
+	EXPECT_THROW(NotificationSource notificationSource(
+	                 transport, std::move(source_), std::move(sink_), format_,
+	                 priority_, ttl_),
+	             uprotocol::transport::NullTransport);
+}
+
 }  // namespace

--- a/test/coverage/communication/PublisherTest.cpp
+++ b/test/coverage/communication/PublisherTest.cpp
@@ -145,4 +145,12 @@ TEST_F(TestPublisher, PublishSuccessWithoutPriority) {
 	          v1::UPriority::UPRIORITY_CS1);
 }
 
+// publisher with null transport
+TEST_F(TestPublisher, PublisherWithNullTransport) {
+	auto transport = nullptr;
+	EXPECT_THROW(Publisher publisher(transport, std::move(topic_), format_,
+	                                 priority_, ttl_),
+	             uprotocol::transport::NullTransport);
+}
+
 }  // namespace

--- a/test/coverage/communication/RpcServerTest.cpp
+++ b/test/coverage/communication/RpcServerTest.cpp
@@ -132,6 +132,20 @@ TEST_F(TestRpcServer, ConstructorValidParams) {
 	ASSERT_NE(serverPtr, nullptr);
 }
 
+// Null transport
+TEST_F(TestRpcServer, CreateWithNullTransport) {
+	// Define a callback function to be used with the RpcServer
+	uprotocol::communication::RpcServer::RpcCallback callback =
+	    RpcCallbackNoReturn;
+
+	auto transport = nullptr;
+	// Attempt to create an RpcServer instance with valid parameters
+	EXPECT_THROW(
+	    auto serverOrStatus = uprotocol::communication::RpcServer::create(
+	        transport, *method_uri_, std::move(callback)),
+	    uprotocol::transport::NullTransport);
+}
+
 // Test to verify RpcServer construction with a specific payload format
 TEST_F(TestRpcServer, ConstructorWithPayloadFormat) {
 	// Define a callback that returns a specific value, simulating a response


### PR DESCRIPTION
All code that takes a shared_ptr<UTransport> parameter, now check for nullptr.