### PR TITLE
Payload builder changes to passthrough an Any, and supporting test.

### DIFF
--- a/include/up-cpp/datamodel/builder/Payload.h
+++ b/include/up-cpp/datamodel/builder/Payload.h
@@ -12,6 +12,7 @@
 #ifndef UP_CPP_DATAMODEL_BUILDER_PAYLOAD_H
 #define UP_CPP_DATAMODEL_BUILDER_PAYLOAD_H
 
+#include <google/protobuf/any.pb.h>
 #include <uprotocol/v1/uattributes.pb.h>
 
 #include <cstdint>
@@ -130,6 +131,13 @@ struct Payload {
 	/// @throws std::out_of_range If the serialized payload format is not valid
 	///                           for v1::UPayloadFormat
 	explicit Payload(Serialized&&);
+
+	/// @brief Creates a Payload builder with a provided protobuf::Any.
+	///
+	/// The contents of value will be moved into the Payload object.
+	///
+	/// @param An initialized google::protobuf::Any object..
+	explicit Payload(const google::protobuf::Any&);
 
 	/// @brief Move constructor.
 	Payload(Payload&&) noexcept;

--- a/src/datamodel/builder/Payload.cpp
+++ b/src/datamodel/builder/Payload.cpp
@@ -46,6 +46,13 @@ Payload::Payload(Serialized&& serialized) {
 	payload_ = std::move(serialized);
 }
 
+// google::protobuf::Any constructor
+Payload::Payload(const google::protobuf::Any& any) {
+	payload_ = std::make_tuple(
+	    std::move(any.SerializeAsString()),
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+}
+
 // Move constructor
 Payload::Payload(Payload&& other) noexcept
     : payload_(std::move(other.payload_)), moved_(std::move(other.moved_)) {}

--- a/test/coverage/datamodel/PayloadBuilderTest.cpp
+++ b/test/coverage/datamodel/PayloadBuilderTest.cpp
@@ -340,6 +340,31 @@ TEST_F(PayloadTest, StringMovePayloadTest) {
 	EXPECT_THROW(auto _ = payload.buildCopy(), Payload::PayloadMoved);
 }
 
+// Create Any and move payload object test
+TEST_F(PayloadTest, AnyMovePayloadTest) {  // NOLINT
+	// Arrange
+	uprotocol::v1::UUri uri_object;  // NOLINT
+	uri_object.set_authority_name(testStringPayload_);
+	google::protobuf::Any any;
+	any.PackFrom(uri_object, "hello_world");
+
+	// Act
+	Payload payload(any);
+	auto [serialized_data, payload_format] = std::move(payload).buildMove();
+
+	// Assert
+	EXPECT_EQ(
+	    payload_format,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+	google::protobuf::Any parsed_any;
+	EXPECT_TRUE(parsed_any.ParseFromString(serialized_data));
+	EXPECT_EQ(parsed_any.type_url(), "hello_world/uprotocol.v1.UUri");
+
+	uprotocol::v1::UUri parsed_uri_object;
+	EXPECT_TRUE(parsed_uri_object.ParseFromString(parsed_any.value()));
+	EXPECT_EQ(parsed_uri_object.authority_name(), testStringPayload_);
+}
+
 /////////////////////RValue String Payload Tests/////////////////////
 
 // Create RValue String Payload


### PR DESCRIPTION
Add constructor to builder::Payload to construct from a protobuf::Any. Add a test to PayloadBuilderTest to verify it works.
