### PR TITLE
UuidBuilderTest.cpp: Use excplicit type not auto

### DIFF
--- a/test/coverage/datamodel/UuidBuilderTest.cpp
+++ b/test/coverage/datamodel/UuidBuilderTest.cpp
@@ -64,7 +64,7 @@ TEST(UuidBuilderTest, WithTimeSource) {
 
 // Test RandomSource
 TEST(UuidBuilderTest, WithRandomSource) {
-	auto fixed_random = 0x1234567890ABCDEF;
+	uint64_t fixed_random = 0x1234567890ABCDEF;
 	auto builder = UuidBuilder::getTestBuilder().withRandomSource(
 	    [fixed_random]() { return fixed_random; });
 	auto uuid = builder.build();


### PR DESCRIPTION
Changed type to an explicit type, instead of using auto to remove a clang-tidy error.

Closes issue #270 