### PR TITLE
Align with re-versioned core API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build up-core-api conan package
         shell: bash
         run: |
-          conan create --version 1.6.0 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp with tests
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
       name: Build up-core-api conan package
       shell: bash
       run: |
-        conan create --version 1.6.0 up-conan-recipes/up-core-api/release
+        conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
 
     - if: matrix.build-mode == 'manual'
       name: Build up-cpp with tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build up-core-api conan package
         shell: bash
         run: |
-          conan create --version 1.6.0 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp with tests
         shell: bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ implementation, such as [up-transport-zenoh-cpp][zenoh-transport-repo].
 Using the recipes found in [up-conan-recipes][conan-recipe-repo], build these
 Conan packages:
 
-1. [up-core-api][spec-repo]: `conan create --version 1.6.0 --build=missing up-core-api/release`
+1. [up-core-api][spec-repo]: `conan create --version 1.6.0-alpha2 --build=missing up-core-api/release`
 
 **NOTE:** all `conan` commands in this document use  Conan 2.x syntax. Please
 adjust accordingly when using Conan 1.x.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-up-core-api/1.6.0
+up-core-api/1.6.0-alpha2
 protobuf/3.21.12
 
 [test_requires]


### PR DESCRIPTION
As part of fixing the version numbers in the core API package, we need to point the 1.0.1 bugfix release at the correct alpha API (alpha2).

We will not go back and fix 1.0.0 since that version will be deprecated in favor of the bugfixed 1.0.1