### PR TITLE
Merge release branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build up-core-api conan package
         shell: bash
         run: |
-          conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha3 up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp with tests
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
       name: Build up-core-api conan package
       shell: bash
       run: |
-        conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
+        conan create --version 1.6.0-alpha3 up-conan-recipes/up-core-api/release
 
     - if: matrix.build-mode == 'manual'
       name: Build up-cpp with tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build up-core-api conan package
         shell: bash
         run: |
-          conan create --version 1.6.0-alpha2 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha3 up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp with tests
         shell: bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ implementation, such as [up-transport-zenoh-cpp][zenoh-transport-repo].
 Using the recipes found in [up-conan-recipes][conan-recipe-repo], build these
 Conan packages:
 
-1. [up-core-api][spec-repo]: `conan create --version 1.6.0-alpha2 --build=missing up-core-api/release`
+1. [up-core-api][spec-repo]: `conan create --version 1.6.0-alpha3 --build=missing up-core-api/release`
 
 **NOTE:** all `conan` commands in this document use  Conan 2.x syntax. Please
 adjust accordingly when using Conan 1.x.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-up-core-api/[~1.6]
+up-core-api/[~1.6, include_prerelease]
 spdlog/[~1.13]
 protobuf/[~3.21]
 


### PR DESCRIPTION
This merge is primarily so that merges from the release branch to main in the future won't have conflicts, while also adjusting for the more updated releases used on main.