### PR TITLE
Adding exception type for empty callback functions

### DIFF
--- a/include/up-cpp/utils/CallbackConnection.h
+++ b/include/up-cpp/utils/CallbackConnection.h
@@ -234,6 +234,18 @@ struct BadConnection : public std::runtime_error {
 	    : std::runtime_error(std::forward<Args>(args)...) {}
 };
 
+/// @brief Thrown if an empty std::function parameter was received
+///
+/// A std::function can be empty. When an empty function is invoked, it will
+/// throw std::bad_function_call. We can check earlier by casting the function
+/// to a boolean. If the check fails, EmptyFunctionObject is thrown. This makes
+/// the error appear earlier without waiting for invokation to occur.
+struct EmptyFunctionObject : public std::invalid_argument {
+	template <typename... Args>
+	EmptyFunctionObject(Args&&... args)
+	    : std::invalid_argument(std::forward<Args>(args)...) {}
+};
+
 template <typename RT, typename... Args>
 struct [[nodiscard]] CalleeHandle {
 	using Conn = Connection<RT, Args...>;

--- a/include/up-cpp/utils/CallbackConnection.h
+++ b/include/up-cpp/utils/CallbackConnection.h
@@ -266,10 +266,20 @@ struct [[nodiscard]] CalleeHandle {
 			    "Attempted to create a connected CalleeHandle with bad "
 			    "connection pointer");
 		}
+
 		if (!callback_) {
 			throw BadConnection(
 			    "Attempted to create a connected CalleeHandle with bad "
 			    "callback pointer");
+		}
+
+		const auto& callback_obj = *callback_;
+		if (!callback_obj) {
+			throw EmptyFunctionObject("Callback function is empty");
+		}
+
+		if (cleanup_ && !cleanup_.value()) {
+			throw EmptyFunctionObject("Cleanup function is empty");
 		}
 	}
 

--- a/test/coverage/communication/NotificationSinkTest.cpp
+++ b/test/coverage/communication/NotificationSinkTest.cpp
@@ -216,14 +216,23 @@ TEST_F(NotificationSinkTest, NullCallback) {
 	    testDefaultSourceUUri_);
 
 	// bind to null callback
-	auto result = NotificationSink::create(transport, transport->getEntityUri(),
-	                                       std::move(nullptr), testTopicUUri_);
+	auto test_create_nullptr = [transport, this]() {
+		std::ignore =
+		    NotificationSink::create(transport, transport->getEntityUri(),
+		                             std::move(nullptr), testTopicUUri_);
+	};
 
-	uprotocol::v1::UMessage msg;
-	auto attr = std::make_shared<uprotocol::v1::UAttributes>();
-	*msg.mutable_attributes() = *attr;
-	msg.set_payload(get_random_string(1400));
-	EXPECT_THROW(transport->mockMessage(msg), std::bad_function_call);
+	using namespace uprotocol::utils;
+
+	EXPECT_THROW(test_create_nullptr(), callbacks::EmptyFunctionObject);
+
+	// Default construct a function object
+	auto test_create_empty = [transport, this]() {
+		std::ignore = NotificationSink::create(
+		    transport, transport->getEntityUri(), {}, testTopicUUri_);
+	};
+
+	EXPECT_THROW(test_create_empty(), callbacks::EmptyFunctionObject);
 }
 
 }  // namespace

--- a/test/coverage/communication/SubscriberTest.cpp
+++ b/test/coverage/communication/SubscriberTest.cpp
@@ -186,14 +186,21 @@ TEST_F(SubscriberTest, SubscribeNullCallback) {
 	    testDefaultSourceUUri_);
 
 	// bind to null callback
-	auto result =
-	    Subscriber::subscribe(transport, testTopicUUri_, std::move(nullptr));
+	auto test_subscribe_nullptr = [transport, this]() {
+		std::ignore = Subscriber::subscribe(transport, testTopicUUri_,
+		                                    std::move(nullptr));
+	};
 
-	uprotocol::v1::UMessage msg;
-	auto attr = std::make_shared<uprotocol::v1::UAttributes>();
-	*msg.mutable_attributes() = *attr;
-	msg.set_payload(get_random_string(1400));
-	EXPECT_THROW(transport->mockMessage(msg), std::bad_function_call);
+	using namespace uprotocol::utils;
+
+	EXPECT_THROW(test_subscribe_nullptr(), callbacks::EmptyFunctionObject);
+
+	// Default construct a function object
+	auto test_subscribe_empty = [transport, this]() {
+		std::ignore = Subscriber::subscribe(transport, testTopicUUri_, {});
+	};
+
+	EXPECT_THROW(test_subscribe_empty(), callbacks::EmptyFunctionObject);
 }
 
 }  // namespace


### PR DESCRIPTION
This exception will be thrown when an empty std::function is passed to the callback connection module. Adding the type first so that tests can be written.

closes #194 