### PR TITLE
Payload Builder supporting google.protobuf.Any

### DIFF
--- a/include/up-cpp/datamodel/builder/Payload.h
+++ b/include/up-cpp/datamodel/builder/Payload.h
@@ -12,6 +12,7 @@
 #ifndef UP_CPP_DATAMODEL_BUILDER_PAYLOAD_H
 #define UP_CPP_DATAMODEL_BUILDER_PAYLOAD_H
 
+#include <google/protobuf/any.pb.h>
 #include <uprotocol/v1/uattributes.pb.h>
 
 #include <cstdint>
@@ -130,6 +131,13 @@ struct Payload {
 	/// @throws std::out_of_range If the serialized payload format is not valid
 	///                           for v1::UPayloadFormat
 	explicit Payload(Serialized&&);
+
+	/// @brief Creates a Payload builder with a provided protobuf::Any.
+	///
+	/// The contents of value will be moved into the Payload object.
+	///
+	/// @param An initialized google::protobuf::Any object..
+	explicit Payload(const google::protobuf::Any&);
 
 	/// @brief Move constructor.
 	Payload(Payload&&) noexcept;

--- a/src/datamodel/builder/Payload.cpp
+++ b/src/datamodel/builder/Payload.cpp
@@ -46,6 +46,13 @@ Payload::Payload(Serialized&& serialized) {
 	payload_ = std::move(serialized);
 }
 
+// google::protobuf::Any constructor
+Payload::Payload(const google::protobuf::Any& any) {
+	payload_ = std::make_tuple(
+	    std::move(any.SerializeAsString()),
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+}
+
 // Move constructor
 Payload::Payload(Payload&& other) noexcept
     : payload_(std::move(other.payload_)), moved_(std::move(other.moved_)) {}

--- a/src/datamodel/builder/Payload.cpp
+++ b/src/datamodel/builder/Payload.cpp
@@ -49,8 +49,8 @@ Payload::Payload(Serialized&& serialized) {
 // google::protobuf::Any constructor
 Payload::Payload(const google::protobuf::Any& any) {
 	payload_ = std::make_tuple(
-	    std::move(any.SerializeAsString()),
-	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+		any.SerializeAsString(),
+		uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);	
 }
 
 // Move constructor

--- a/test/coverage/datamodel/PayloadBuilderTest.cpp
+++ b/test/coverage/datamodel/PayloadBuilderTest.cpp
@@ -340,6 +340,31 @@ TEST_F(PayloadTest, StringMovePayloadTest) {
 	EXPECT_THROW(auto _ = payload.buildCopy(), Payload::PayloadMoved);
 }
 
+// Create Any and move payload object test
+TEST_F(PayloadTest, AnyMovePayloadTest) {  // NOLINT
+	// Arrange
+	uprotocol::v1::UUri uri_object;  // NOLINT
+	uri_object.set_authority_name(testStringPayload_);
+	google::protobuf::Any any;
+	any.PackFrom(uri_object, "hello_world");
+
+	// Act
+	Payload payload(any);
+	auto [serialized_data, payload_format] = std::move(payload).buildMove();
+
+	// Assert
+	EXPECT_EQ(
+	    payload_format,
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+	google::protobuf::Any parsed_any;
+	EXPECT_TRUE(parsed_any.ParseFromString(serialized_data));
+	EXPECT_EQ(parsed_any.type_url(), "hello_world/uprotocol.v1.UUri");
+
+	uprotocol::v1::UUri parsed_uri_object;
+	EXPECT_TRUE(parsed_uri_object.ParseFromString(parsed_any.value()));
+	EXPECT_EQ(parsed_uri_object.authority_name(), testStringPayload_);
+}
+
 /////////////////////RValue String Payload Tests/////////////////////
 
 // Create RValue String Payload

--- a/test/coverage/datamodel/PayloadBuilderTest.cpp
+++ b/test/coverage/datamodel/PayloadBuilderTest.cpp
@@ -130,7 +130,9 @@ TEST_F(PayloadTest, CreateSerializedProtobufPayloadAndMoveTwiceExceptionTest) {
 	          uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF);
 	EXPECT_EQ(payloadData, uriObject.SerializeAsString());
 
-	EXPECT_THROW(std::move(payload).buildMove(), Payload::PayloadMoved);
+	EXPECT_THROW({
+		auto _ = std::move(payload).buildMove();
+	}, Payload::PayloadMoved);	
 }
 
 // Create serialized protobuf payload. Call build after move.

--- a/test/coverage/datamodel/PayloadBuilderTest.cpp
+++ b/test/coverage/datamodel/PayloadBuilderTest.cpp
@@ -101,7 +101,7 @@ TEST_F(PayloadTest, CreateSerializedProtobufPayloadAndMoveTest) {
 
 	// Act
 	Payload payload(uriObject);
-	auto& [payload_reference, _] = payload.buildCopy();
+	auto& [payload_reference, payload_format] = payload.buildCopy();
 	const void* original_address = payload_reference.data();
 
 	// Assert
@@ -110,7 +110,7 @@ TEST_F(PayloadTest, CreateSerializedProtobufPayloadAndMoveTest) {
 	          uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF);
 	EXPECT_EQ(payloadData, expectedPayloadData);
 
-	EXPECT_THROW(auto _ = payload.buildCopy(), Payload::PayloadMoved);
+	EXPECT_THROW(auto result = payload.buildCopy(), Payload::PayloadMoved);
 	EXPECT_EQ(original_address, payloadData.data());
 }
 


### PR DESCRIPTION
This PR reopens [PR 287](https://github.com/eclipse-uprotocol/up-cpp/pull/287). Added the code from debruce's commits manually, since the branch (and the repo) are not available. 

Add constructor to Payload. Add test case to PayloadBuilderTest to exercise this constructor by creating an Any containing a uuri, passing it to the constructor, building it, and then deserializing the Any, and the contained uuri.