### PR TITLE
fixed instance id in RpcServer

### DIFF
--- a/src/communication/RpcServer.cpp
+++ b/src/communication/RpcServer.cpp
@@ -124,9 +124,9 @@ v1::UStatus RpcServer::connect(const v1::UUri& method, RpcCallback&& callback) {
 	    []() {
 		    v1::UUri any_uri;
 		    any_uri.set_authority_name("*");
-		    // Instance ID 0 and UE ID FFFF for wildcard
+		    // Instance ID FFFF and UE ID FFFF for wildcard
 		    constexpr auto DEFAULT_INSTANCE_ID_WITH_WILDCARD_SERVICE_ID =
-		        0x0000FFFF;
+		        0xFFFFFFFF;
 		    constexpr auto VERSION_MAJOR_WILDCARD = 0xFF;
 		    constexpr auto RESOURCE_ID_WILDCARD = 0xFFFF;
 		    any_uri.set_ue_id(DEFAULT_INSTANCE_ID_WITH_WILDCARD_SERVICE_ID);


### PR DESCRIPTION
This PR replaces the default instance id 0000 with the wildcard id FFFF when creating the source filter in the connect method of RpcServer. 
This fixes a bug that causes a test in the pipline of https://github.com/eclipse-uprotocol/up-transport-zenoh-cpp/pull/121 to fail. 

Closes #323